### PR TITLE
Sort directories in TestSuite.initializeFromDirectory

### DIFF
--- a/src/front-ends/standalone/testsuite-core/src/org/sbml/testsuite/core/TestSuite.java
+++ b/src/front-ends/standalone/testsuite-core/src/org/sbml/testsuite/core/TestSuite.java
@@ -261,6 +261,7 @@ public class TestSuite
                 return arg1.length() == 5;
             }
         });
+        Arrays.sort(files);
         for (String file : files)
         {
             TestCase newTestCase = new TestCase(new File(casesDirectory, file));


### PR DESCRIPTION
`File.list` method doesn't return file/directory names in any specific order, so we have to sort the resulting array in `TestSuite.initializeFromDirectory` method.
https://docs.oracle.com/javase/8/docs/api/java/io/File.html#list--

Without sorting, `TestSuite.initializeFromDirectory` method grabs the wrong directory in my environment, ubuntu(trusty) + jdk8.