### PR TITLE
Fix L3 models in 0D-compartment tests.

### DIFF
--- a/cases/semantic/00048/00048-sbml-l3v1.xml
+++ b/cases/semantic/00048/00048-sbml-l3v1.xml
@@ -17,8 +17,8 @@
       <compartment id="compartment" name="compartment" spatialDimensions="0" constant="true"/>
     </listOfCompartments>
     <listOfSpecies>
-      <species id="S1" name="S1" compartment="compartment" initialAmount="0.015" substanceUnits="substance" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
-      <species id="S2" name="S2" compartment="compartment" initialAmount="0" substanceUnits="substance" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
+      <species id="S1" name="S1" compartment="compartment" initialAmount="0.015" substanceUnits="substance" hasOnlySubstanceUnits="true" boundaryCondition="false" constant="false"/>
+      <species id="S2" name="S2" compartment="compartment" initialAmount="0" substanceUnits="substance" hasOnlySubstanceUnits="true" boundaryCondition="false" constant="false"/>
     </listOfSpecies>
     <listOfParameters>
       <parameter id="k1" name="k1" value="1" constant="true"/>

--- a/cases/semantic/00048/00048-sbml-l3v2.xml
+++ b/cases/semantic/00048/00048-sbml-l3v2.xml
@@ -17,8 +17,8 @@
       <compartment id="compartment" name="compartment" spatialDimensions="0" constant="true"/>
     </listOfCompartments>
     <listOfSpecies>
-      <species id="S1" name="S1" compartment="compartment" initialAmount="0.015" substanceUnits="substance" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
-      <species id="S2" name="S2" compartment="compartment" initialAmount="0" substanceUnits="substance" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
+      <species id="S1" name="S1" compartment="compartment" initialAmount="0.015" substanceUnits="substance" hasOnlySubstanceUnits="true" boundaryCondition="false" constant="false"/>
+      <species id="S2" name="S2" compartment="compartment" initialAmount="0" substanceUnits="substance" hasOnlySubstanceUnits="true" boundaryCondition="false" constant="false"/>
     </listOfSpecies>
     <listOfParameters>
       <parameter id="k1" name="k1" value="1" constant="true"/>

--- a/cases/semantic/00049/00049-sbml-l3v1.xml
+++ b/cases/semantic/00049/00049-sbml-l3v1.xml
@@ -17,9 +17,9 @@
       <compartment id="compartment" name="compartment" spatialDimensions="0" constant="true"/>
     </listOfCompartments>
     <listOfSpecies>
-      <species id="S1" name="S1" compartment="compartment" initialAmount="0.1" substanceUnits="substance" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
-      <species id="S2" name="S2" compartment="compartment" initialAmount="0.2" substanceUnits="substance" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
-      <species id="S3" name="S3" compartment="compartment" initialAmount="0.1" substanceUnits="substance" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
+      <species id="S1" name="S1" compartment="compartment" initialAmount="0.1" substanceUnits="substance" hasOnlySubstanceUnits="true" boundaryCondition="false" constant="false"/>
+      <species id="S2" name="S2" compartment="compartment" initialAmount="0.2" substanceUnits="substance" hasOnlySubstanceUnits="true" boundaryCondition="false" constant="false"/>
+      <species id="S3" name="S3" compartment="compartment" initialAmount="0.1" substanceUnits="substance" hasOnlySubstanceUnits="true" boundaryCondition="false" constant="false"/>
     </listOfSpecies>
     <listOfParameters>
       <parameter id="k1" name="k1" value="0.75" constant="true"/>

--- a/cases/semantic/00049/00049-sbml-l3v2.xml
+++ b/cases/semantic/00049/00049-sbml-l3v2.xml
@@ -17,9 +17,9 @@
       <compartment id="compartment" name="compartment" spatialDimensions="0" constant="true"/>
     </listOfCompartments>
     <listOfSpecies>
-      <species id="S1" name="S1" compartment="compartment" initialAmount="0.1" substanceUnits="substance" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
-      <species id="S2" name="S2" compartment="compartment" initialAmount="0.2" substanceUnits="substance" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
-      <species id="S3" name="S3" compartment="compartment" initialAmount="0.1" substanceUnits="substance" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
+      <species id="S1" name="S1" compartment="compartment" initialAmount="0.1" substanceUnits="substance" hasOnlySubstanceUnits="true" boundaryCondition="false" constant="false"/>
+      <species id="S2" name="S2" compartment="compartment" initialAmount="0.2" substanceUnits="substance" hasOnlySubstanceUnits="true" boundaryCondition="false" constant="false"/>
+      <species id="S3" name="S3" compartment="compartment" initialAmount="0.1" substanceUnits="substance" hasOnlySubstanceUnits="true" boundaryCondition="false" constant="false"/>
     </listOfSpecies>
     <listOfParameters>
       <parameter id="k1" name="k1" value="0.75" constant="true"/>

--- a/cases/semantic/00050/00050-sbml-l3v1.xml
+++ b/cases/semantic/00050/00050-sbml-l3v1.xml
@@ -17,10 +17,10 @@
       <compartment id="compartment" name="compartment" spatialDimensions="0" constant="true"/>
     </listOfCompartments>
     <listOfSpecies>
-      <species id="S1" name="S1" compartment="compartment" initialAmount="0.0001" substanceUnits="substance" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
-      <species id="S2" name="S2" compartment="compartment" initialAmount="0.0001" substanceUnits="substance" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
-      <species id="S3" name="S3" compartment="compartment" initialAmount="0.0002" substanceUnits="substance" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
-      <species id="S4" name="S4" compartment="compartment" initialAmount="0.0001" substanceUnits="substance" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
+      <species id="S1" name="S1" compartment="compartment" initialAmount="0.0001" substanceUnits="substance" hasOnlySubstanceUnits="true" boundaryCondition="false" constant="false"/>
+      <species id="S2" name="S2" compartment="compartment" initialAmount="0.0001" substanceUnits="substance" hasOnlySubstanceUnits="true" boundaryCondition="false" constant="false"/>
+      <species id="S3" name="S3" compartment="compartment" initialAmount="0.0002" substanceUnits="substance" hasOnlySubstanceUnits="true" boundaryCondition="false" constant="false"/>
+      <species id="S4" name="S4" compartment="compartment" initialAmount="0.0001" substanceUnits="substance" hasOnlySubstanceUnits="true" boundaryCondition="false" constant="false"/>
     </listOfSpecies>
     <listOfParameters>
       <parameter id="k1" name="k1" value="7500" constant="true"/>

--- a/cases/semantic/00050/00050-sbml-l3v2.xml
+++ b/cases/semantic/00050/00050-sbml-l3v2.xml
@@ -17,10 +17,10 @@
       <compartment id="compartment" name="compartment" spatialDimensions="0" constant="true"/>
     </listOfCompartments>
     <listOfSpecies>
-      <species id="S1" name="S1" compartment="compartment" initialAmount="0.0001" substanceUnits="substance" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
-      <species id="S2" name="S2" compartment="compartment" initialAmount="0.0001" substanceUnits="substance" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
-      <species id="S3" name="S3" compartment="compartment" initialAmount="0.0002" substanceUnits="substance" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
-      <species id="S4" name="S4" compartment="compartment" initialAmount="0.0001" substanceUnits="substance" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
+      <species id="S1" name="S1" compartment="compartment" initialAmount="0.0001" substanceUnits="substance" hasOnlySubstanceUnits="true" boundaryCondition="false" constant="false"/>
+      <species id="S2" name="S2" compartment="compartment" initialAmount="0.0001" substanceUnits="substance" hasOnlySubstanceUnits="true" boundaryCondition="false" constant="false"/>
+      <species id="S3" name="S3" compartment="compartment" initialAmount="0.0002" substanceUnits="substance" hasOnlySubstanceUnits="true" boundaryCondition="false" constant="false"/>
+      <species id="S4" name="S4" compartment="compartment" initialAmount="0.0001" substanceUnits="substance" hasOnlySubstanceUnits="true" boundaryCondition="false" constant="false"/>
     </listOfSpecies>
     <listOfParameters>
       <parameter id="k1" name="k1" value="7500" constant="true"/>

--- a/cases/semantic/00097/00097-sbml-l3v1.xml
+++ b/cases/semantic/00097/00097-sbml-l3v1.xml
@@ -36,8 +36,8 @@
       <compartment id="compartment" name="compartment" spatialDimensions="0" constant="true"/>
     </listOfCompartments>
     <listOfSpecies>
-      <species id="S1" name="S1" compartment="compartment" initialAmount="0.00015" substanceUnits="substance" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
-      <species id="S2" name="S2" compartment="compartment" initialAmount="0.00015" substanceUnits="substance" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
+      <species id="S1" name="S1" compartment="compartment" initialAmount="0.00015" substanceUnits="substance" hasOnlySubstanceUnits="true" boundaryCondition="false" constant="false"/>
+      <species id="S2" name="S2" compartment="compartment" initialAmount="0.00015" substanceUnits="substance" hasOnlySubstanceUnits="true" boundaryCondition="false" constant="false"/>
     </listOfSpecies>
     <listOfParameters>
       <parameter id="k1" name="k1" value="1" constant="true"/>

--- a/cases/semantic/00097/00097-sbml-l3v2.xml
+++ b/cases/semantic/00097/00097-sbml-l3v2.xml
@@ -36,8 +36,8 @@
       <compartment id="compartment" name="compartment" spatialDimensions="0" constant="true"/>
     </listOfCompartments>
     <listOfSpecies>
-      <species id="S1" name="S1" compartment="compartment" initialAmount="0.00015" substanceUnits="substance" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
-      <species id="S2" name="S2" compartment="compartment" initialAmount="0.00015" substanceUnits="substance" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
+      <species id="S1" name="S1" compartment="compartment" initialAmount="0.00015" substanceUnits="substance" hasOnlySubstanceUnits="true" boundaryCondition="false" constant="false"/>
+      <species id="S2" name="S2" compartment="compartment" initialAmount="0.00015" substanceUnits="substance" hasOnlySubstanceUnits="true" boundaryCondition="false" constant="false"/>
     </listOfSpecies>
     <listOfParameters>
       <parameter id="k1" name="k1" value="1" constant="true"/>

--- a/cases/semantic/00100/00100-sbml-l3v1.xml
+++ b/cases/semantic/00100/00100-sbml-l3v1.xml
@@ -40,9 +40,9 @@
       <compartment id="compartment" name="compartment" spatialDimensions="0" constant="true"/>
     </listOfCompartments>
     <listOfSpecies>
-      <species id="S1" name="S1" compartment="compartment" initialAmount="0.0001" substanceUnits="substance" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
-      <species id="S2" name="S2" compartment="compartment" initialAmount="0.0002" substanceUnits="substance" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
-      <species id="S3" name="S3" compartment="compartment" initialAmount="0.0001" substanceUnits="substance" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
+      <species id="S1" name="S1" compartment="compartment" initialAmount="0.0001" substanceUnits="substance" hasOnlySubstanceUnits="true" boundaryCondition="false" constant="false"/>
+      <species id="S2" name="S2" compartment="compartment" initialAmount="0.0002" substanceUnits="substance" hasOnlySubstanceUnits="true" boundaryCondition="false" constant="false"/>
+      <species id="S3" name="S3" compartment="compartment" initialAmount="0.0001" substanceUnits="substance" hasOnlySubstanceUnits="true" boundaryCondition="false" constant="false"/>
     </listOfSpecies>
     <listOfParameters>
       <parameter id="k1" name="k1" value="0.75" constant="true"/>

--- a/cases/semantic/00100/00100-sbml-l3v2.xml
+++ b/cases/semantic/00100/00100-sbml-l3v2.xml
@@ -40,9 +40,9 @@
       <compartment id="compartment" name="compartment" spatialDimensions="0" constant="true"/>
     </listOfCompartments>
     <listOfSpecies>
-      <species id="S1" name="S1" compartment="compartment" initialAmount="0.0001" substanceUnits="substance" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
-      <species id="S2" name="S2" compartment="compartment" initialAmount="0.0002" substanceUnits="substance" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
-      <species id="S3" name="S3" compartment="compartment" initialAmount="0.0001" substanceUnits="substance" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
+      <species id="S1" name="S1" compartment="compartment" initialAmount="0.0001" substanceUnits="substance" hasOnlySubstanceUnits="true" boundaryCondition="false" constant="false"/>
+      <species id="S2" name="S2" compartment="compartment" initialAmount="0.0002" substanceUnits="substance" hasOnlySubstanceUnits="true" boundaryCondition="false" constant="false"/>
+      <species id="S3" name="S3" compartment="compartment" initialAmount="0.0001" substanceUnits="substance" hasOnlySubstanceUnits="true" boundaryCondition="false" constant="false"/>
     </listOfSpecies>
     <listOfParameters>
       <parameter id="k1" name="k1" value="0.75" constant="true"/>

--- a/cases/semantic/00103/00103-sbml-l3v1.xml
+++ b/cases/semantic/00103/00103-sbml-l3v1.xml
@@ -36,10 +36,10 @@
       <compartment id="compartment" name="compartment" spatialDimensions="0" constant="true"/>
     </listOfCompartments>
     <listOfSpecies>
-      <species id="S1" name="S1" compartment="compartment" initialAmount="0.0001" substanceUnits="substance" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
-      <species id="S2" name="S2" compartment="compartment" initialAmount="0.0001" substanceUnits="substance" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
-      <species id="S3" name="S3" compartment="compartment" initialAmount="0.0002" substanceUnits="substance" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
-      <species id="S4" name="S4" compartment="compartment" initialAmount="0.0001" substanceUnits="substance" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
+      <species id="S1" name="S1" compartment="compartment" initialAmount="0.0001" substanceUnits="substance" hasOnlySubstanceUnits="true" boundaryCondition="false" constant="false"/>
+      <species id="S2" name="S2" compartment="compartment" initialAmount="0.0001" substanceUnits="substance" hasOnlySubstanceUnits="true" boundaryCondition="false" constant="false"/>
+      <species id="S3" name="S3" compartment="compartment" initialAmount="0.0002" substanceUnits="substance" hasOnlySubstanceUnits="true" boundaryCondition="false" constant="false"/>
+      <species id="S4" name="S4" compartment="compartment" initialAmount="0.0001" substanceUnits="substance" hasOnlySubstanceUnits="true" boundaryCondition="false" constant="false"/>
     </listOfSpecies>
     <listOfParameters>
       <parameter id="k1" name="k1" value="7500" constant="true"/>

--- a/cases/semantic/00103/00103-sbml-l3v2.xml
+++ b/cases/semantic/00103/00103-sbml-l3v2.xml
@@ -36,10 +36,10 @@
       <compartment id="compartment" name="compartment" spatialDimensions="0" constant="true"/>
     </listOfCompartments>
     <listOfSpecies>
-      <species id="S1" name="S1" compartment="compartment" initialAmount="0.0001" substanceUnits="substance" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
-      <species id="S2" name="S2" compartment="compartment" initialAmount="0.0001" substanceUnits="substance" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
-      <species id="S3" name="S3" compartment="compartment" initialAmount="0.0002" substanceUnits="substance" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
-      <species id="S4" name="S4" compartment="compartment" initialAmount="0.0001" substanceUnits="substance" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
+      <species id="S1" name="S1" compartment="compartment" initialAmount="0.0001" substanceUnits="substance" hasOnlySubstanceUnits="true" boundaryCondition="false" constant="false"/>
+      <species id="S2" name="S2" compartment="compartment" initialAmount="0.0001" substanceUnits="substance" hasOnlySubstanceUnits="true" boundaryCondition="false" constant="false"/>
+      <species id="S3" name="S3" compartment="compartment" initialAmount="0.0002" substanceUnits="substance" hasOnlySubstanceUnits="true" boundaryCondition="false" constant="false"/>
+      <species id="S4" name="S4" compartment="compartment" initialAmount="0.0001" substanceUnits="substance" hasOnlySubstanceUnits="true" boundaryCondition="false" constant="false"/>
     </listOfSpecies>
     <listOfParameters>
       <parameter id="k1" name="k1" value="7500" constant="true"/>

--- a/cases/semantic/00155/00155-sbml-l3v1.xml
+++ b/cases/semantic/00155/00155-sbml-l3v1.xml
@@ -17,10 +17,10 @@
       <compartment id="compartment" name="compartment" spatialDimensions="0" constant="true"/>
     </listOfCompartments>
     <listOfSpecies>
-      <species id="S1" name="S1" compartment="compartment" initialAmount="0.001" substanceUnits="substance" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
-      <species id="S2" name="S2" compartment="compartment" initialAmount="0.0015" substanceUnits="substance" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
-      <species id="S3" name="S3" compartment="compartment" initialAmount="0.001" substanceUnits="substance" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
-      <species id="S4" name="S4" compartment="compartment" substanceUnits="substance" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
+      <species id="S1" name="S1" compartment="compartment" initialAmount="0.001" substanceUnits="substance" hasOnlySubstanceUnits="true" boundaryCondition="false" constant="false"/>
+      <species id="S2" name="S2" compartment="compartment" initialAmount="0.0015" substanceUnits="substance" hasOnlySubstanceUnits="true" boundaryCondition="false" constant="false"/>
+      <species id="S3" name="S3" compartment="compartment" initialAmount="0.001" substanceUnits="substance" hasOnlySubstanceUnits="true" boundaryCondition="false" constant="false"/>
+      <species id="S4" name="S4" compartment="compartment" substanceUnits="substance" hasOnlySubstanceUnits="true" boundaryCondition="false" constant="false"/>
     </listOfSpecies>
     <listOfParameters>
       <parameter id="k1" name="k1" value="1500" constant="true"/>

--- a/cases/semantic/00155/00155-sbml-l3v2.xml
+++ b/cases/semantic/00155/00155-sbml-l3v2.xml
@@ -17,10 +17,10 @@
       <compartment id="compartment" name="compartment" spatialDimensions="0" constant="true"/>
     </listOfCompartments>
     <listOfSpecies>
-      <species id="S1" name="S1" compartment="compartment" initialAmount="0.001" substanceUnits="substance" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
-      <species id="S2" name="S2" compartment="compartment" initialAmount="0.0015" substanceUnits="substance" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
-      <species id="S3" name="S3" compartment="compartment" initialAmount="0.001" substanceUnits="substance" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
-      <species id="S4" name="S4" compartment="compartment" substanceUnits="substance" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
+      <species id="S1" name="S1" compartment="compartment" initialAmount="0.001" substanceUnits="substance" hasOnlySubstanceUnits="true" boundaryCondition="false" constant="false"/>
+      <species id="S2" name="S2" compartment="compartment" initialAmount="0.0015" substanceUnits="substance" hasOnlySubstanceUnits="true" boundaryCondition="false" constant="false"/>
+      <species id="S3" name="S3" compartment="compartment" initialAmount="0.001" substanceUnits="substance" hasOnlySubstanceUnits="true" boundaryCondition="false" constant="false"/>
+      <species id="S4" name="S4" compartment="compartment" substanceUnits="substance" hasOnlySubstanceUnits="true" boundaryCondition="false" constant="false"/>
     </listOfSpecies>
     <listOfParameters>
       <parameter id="k1" name="k1" value="1500" constant="true"/>

--- a/cases/semantic/00156/00156-sbml-l3v1.xml
+++ b/cases/semantic/00156/00156-sbml-l3v1.xml
@@ -17,9 +17,9 @@
       <compartment id="compartment" name="compartment" spatialDimensions="0" constant="true"/>
     </listOfCompartments>
     <listOfSpecies>
-      <species id="S1" name="S1" compartment="compartment" initialAmount="0.01" substanceUnits="substance" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
-      <species id="S2" name="S2" compartment="compartment" initialAmount="0.015" substanceUnits="substance" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
-      <species id="S3" name="S3" compartment="compartment" substanceUnits="substance" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
+      <species id="S1" name="S1" compartment="compartment" initialAmount="0.01" substanceUnits="substance" hasOnlySubstanceUnits="true" boundaryCondition="false" constant="false"/>
+      <species id="S2" name="S2" compartment="compartment" initialAmount="0.015" substanceUnits="substance" hasOnlySubstanceUnits="true" boundaryCondition="false" constant="false"/>
+      <species id="S3" name="S3" compartment="compartment" substanceUnits="substance" hasOnlySubstanceUnits="true" boundaryCondition="false" constant="false"/>
     </listOfSpecies>
     <listOfParameters>
       <parameter id="k1" name="k1" value="0.75" constant="true"/>

--- a/cases/semantic/00156/00156-sbml-l3v2.xml
+++ b/cases/semantic/00156/00156-sbml-l3v2.xml
@@ -17,9 +17,9 @@
       <compartment id="compartment" name="compartment" spatialDimensions="0" constant="true"/>
     </listOfCompartments>
     <listOfSpecies>
-      <species id="S1" name="S1" compartment="compartment" initialAmount="0.01" substanceUnits="substance" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
-      <species id="S2" name="S2" compartment="compartment" initialAmount="0.015" substanceUnits="substance" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
-      <species id="S3" name="S3" compartment="compartment" substanceUnits="substance" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
+      <species id="S1" name="S1" compartment="compartment" initialAmount="0.01" substanceUnits="substance" hasOnlySubstanceUnits="true" boundaryCondition="false" constant="false"/>
+      <species id="S2" name="S2" compartment="compartment" initialAmount="0.015" substanceUnits="substance" hasOnlySubstanceUnits="true" boundaryCondition="false" constant="false"/>
+      <species id="S3" name="S3" compartment="compartment" substanceUnits="substance" hasOnlySubstanceUnits="true" boundaryCondition="false" constant="false"/>
     </listOfSpecies>
     <listOfParameters>
       <parameter id="k1" name="k1" value="0.75" constant="true"/>

--- a/cases/semantic/00238/00238-sbml-l3v1.xml
+++ b/cases/semantic/00238/00238-sbml-l3v1.xml
@@ -17,8 +17,8 @@
       <compartment id="compartment" name="compartment" spatialDimensions="0" constant="true"/>
     </listOfCompartments>
     <listOfSpecies>
-      <species id="S1" name="S1" compartment="compartment" initialAmount="0.15" substanceUnits="substance" hasOnlySubstanceUnits="false" boundaryCondition="true" constant="false"/>
-      <species id="S2" name="S2" compartment="compartment" initialAmount="0" substanceUnits="substance" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
+      <species id="S1" name="S1" compartment="compartment" initialAmount="0.15" substanceUnits="substance" hasOnlySubstanceUnits="true" boundaryCondition="true" constant="false"/>
+      <species id="S2" name="S2" compartment="compartment" initialAmount="0" substanceUnits="substance" hasOnlySubstanceUnits="true" boundaryCondition="false" constant="false"/>
     </listOfSpecies>
     <listOfParameters>
       <parameter id="k1" name="k1" value="1.023" constant="true"/>

--- a/cases/semantic/00238/00238-sbml-l3v2.xml
+++ b/cases/semantic/00238/00238-sbml-l3v2.xml
@@ -17,8 +17,8 @@
       <compartment id="compartment" name="compartment" spatialDimensions="0" constant="true"/>
     </listOfCompartments>
     <listOfSpecies>
-      <species id="S1" name="S1" compartment="compartment" initialAmount="0.15" substanceUnits="substance" hasOnlySubstanceUnits="false" boundaryCondition="true" constant="false"/>
-      <species id="S2" name="S2" compartment="compartment" initialAmount="0" substanceUnits="substance" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
+      <species id="S1" name="S1" compartment="compartment" initialAmount="0.15" substanceUnits="substance" hasOnlySubstanceUnits="true" boundaryCondition="true" constant="false"/>
+      <species id="S2" name="S2" compartment="compartment" initialAmount="0" substanceUnits="substance" hasOnlySubstanceUnits="true" boundaryCondition="false" constant="false"/>
     </listOfSpecies>
     <listOfParameters>
       <parameter id="k1" name="k1" value="1.023" constant="true"/>

--- a/cases/semantic/00239/00239-sbml-l3v1.xml
+++ b/cases/semantic/00239/00239-sbml-l3v1.xml
@@ -17,8 +17,8 @@
       <compartment id="compartment" name="compartment" spatialDimensions="0" constant="true"/>
     </listOfCompartments>
     <listOfSpecies>
-      <species id="S1" name="S1" compartment="compartment" initialAmount="0.15" substanceUnits="substance" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
-      <species id="S2" name="S2" compartment="compartment" initialAmount="0" substanceUnits="substance" hasOnlySubstanceUnits="false" boundaryCondition="true" constant="false"/>
+      <species id="S1" name="S1" compartment="compartment" initialAmount="0.15" substanceUnits="substance" hasOnlySubstanceUnits="true" boundaryCondition="false" constant="false"/>
+      <species id="S2" name="S2" compartment="compartment" initialAmount="0" substanceUnits="substance" hasOnlySubstanceUnits="true" boundaryCondition="true" constant="false"/>
     </listOfSpecies>
     <listOfParameters>
       <parameter id="k1" name="k1" value="1.023" constant="true"/>

--- a/cases/semantic/00239/00239-sbml-l3v2.xml
+++ b/cases/semantic/00239/00239-sbml-l3v2.xml
@@ -17,8 +17,8 @@
       <compartment id="compartment" name="compartment" spatialDimensions="0" constant="true"/>
     </listOfCompartments>
     <listOfSpecies>
-      <species id="S1" name="S1" compartment="compartment" initialAmount="0.15" substanceUnits="substance" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
-      <species id="S2" name="S2" compartment="compartment" initialAmount="0" substanceUnits="substance" hasOnlySubstanceUnits="false" boundaryCondition="true" constant="false"/>
+      <species id="S1" name="S1" compartment="compartment" initialAmount="0.15" substanceUnits="substance" hasOnlySubstanceUnits="true" boundaryCondition="false" constant="false"/>
+      <species id="S2" name="S2" compartment="compartment" initialAmount="0" substanceUnits="substance" hasOnlySubstanceUnits="true" boundaryCondition="true" constant="false"/>
     </listOfSpecies>
     <listOfParameters>
       <parameter id="k1" name="k1" value="1.023" constant="true"/>

--- a/cases/semantic/00240/00240-sbml-l3v1.xml
+++ b/cases/semantic/00240/00240-sbml-l3v1.xml
@@ -17,9 +17,9 @@
       <compartment id="compartment" name="compartment" spatialDimensions="0" constant="true"/>
     </listOfCompartments>
     <listOfSpecies>
-      <species id="S1" name="S1" compartment="compartment" initialAmount="1e-006" substanceUnits="substance" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
-      <species id="S2" name="S2" compartment="compartment" initialAmount="2e-006" substanceUnits="substance" hasOnlySubstanceUnits="false" boundaryCondition="true" constant="false"/>
-      <species id="S3" name="S3" compartment="compartment" initialAmount="1e-006" substanceUnits="substance" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
+      <species id="S1" name="S1" compartment="compartment" initialAmount="1e-006" substanceUnits="substance" hasOnlySubstanceUnits="true" boundaryCondition="false" constant="false"/>
+      <species id="S2" name="S2" compartment="compartment" initialAmount="2e-006" substanceUnits="substance" hasOnlySubstanceUnits="true" boundaryCondition="true" constant="false"/>
+      <species id="S3" name="S3" compartment="compartment" initialAmount="1e-006" substanceUnits="substance" hasOnlySubstanceUnits="true" boundaryCondition="false" constant="false"/>
     </listOfSpecies>
     <listOfParameters>
       <parameter id="k1" name="k1" value="9.8" constant="true"/>

--- a/cases/semantic/00240/00240-sbml-l3v2.xml
+++ b/cases/semantic/00240/00240-sbml-l3v2.xml
@@ -17,9 +17,9 @@
       <compartment id="compartment" name="compartment" spatialDimensions="0" constant="true"/>
     </listOfCompartments>
     <listOfSpecies>
-      <species id="S1" name="S1" compartment="compartment" initialAmount="1e-06" substanceUnits="substance" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
-      <species id="S2" name="S2" compartment="compartment" initialAmount="2e-06" substanceUnits="substance" hasOnlySubstanceUnits="false" boundaryCondition="true" constant="false"/>
-      <species id="S3" name="S3" compartment="compartment" initialAmount="1e-06" substanceUnits="substance" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
+      <species id="S1" name="S1" compartment="compartment" initialAmount="1e-06" substanceUnits="substance" hasOnlySubstanceUnits="true" boundaryCondition="false" constant="false"/>
+      <species id="S2" name="S2" compartment="compartment" initialAmount="2e-06" substanceUnits="substance" hasOnlySubstanceUnits="true" boundaryCondition="true" constant="false"/>
+      <species id="S3" name="S3" compartment="compartment" initialAmount="1e-06" substanceUnits="substance" hasOnlySubstanceUnits="true" boundaryCondition="false" constant="false"/>
     </listOfSpecies>
     <listOfParameters>
       <parameter id="k1" name="k1" value="9.8" constant="true"/>

--- a/cases/semantic/00241/00241-sbml-l3v1.xml
+++ b/cases/semantic/00241/00241-sbml-l3v1.xml
@@ -17,9 +17,9 @@
       <compartment id="compartment" name="compartment" spatialDimensions="0" constant="true"/>
     </listOfCompartments>
     <listOfSpecies>
-      <species id="S1" name="S1" compartment="compartment" initialAmount="1e-006" substanceUnits="substance" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
-      <species id="S2" name="S2" compartment="compartment" initialAmount="2e-006" substanceUnits="substance" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
-      <species id="S3" name="S3" compartment="compartment" initialAmount="1e-006" substanceUnits="substance" hasOnlySubstanceUnits="false" boundaryCondition="true" constant="false"/>
+      <species id="S1" name="S1" compartment="compartment" initialAmount="1e-006" substanceUnits="substance" hasOnlySubstanceUnits="true" boundaryCondition="false" constant="false"/>
+      <species id="S2" name="S2" compartment="compartment" initialAmount="2e-006" substanceUnits="substance" hasOnlySubstanceUnits="true" boundaryCondition="false" constant="false"/>
+      <species id="S3" name="S3" compartment="compartment" initialAmount="1e-006" substanceUnits="substance" hasOnlySubstanceUnits="true" boundaryCondition="true" constant="false"/>
     </listOfSpecies>
     <listOfParameters>
       <parameter id="k1" name="k1" value="9.8" constant="true"/>

--- a/cases/semantic/00241/00241-sbml-l3v2.xml
+++ b/cases/semantic/00241/00241-sbml-l3v2.xml
@@ -17,9 +17,9 @@
       <compartment id="compartment" name="compartment" spatialDimensions="0" constant="true"/>
     </listOfCompartments>
     <listOfSpecies>
-      <species id="S1" name="S1" compartment="compartment" initialAmount="1e-06" substanceUnits="substance" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
-      <species id="S2" name="S2" compartment="compartment" initialAmount="2e-06" substanceUnits="substance" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
-      <species id="S3" name="S3" compartment="compartment" initialAmount="1e-06" substanceUnits="substance" hasOnlySubstanceUnits="false" boundaryCondition="true" constant="false"/>
+      <species id="S1" name="S1" compartment="compartment" initialAmount="1e-06" substanceUnits="substance" hasOnlySubstanceUnits="true" boundaryCondition="false" constant="false"/>
+      <species id="S2" name="S2" compartment="compartment" initialAmount="2e-06" substanceUnits="substance" hasOnlySubstanceUnits="true" boundaryCondition="false" constant="false"/>
+      <species id="S3" name="S3" compartment="compartment" initialAmount="1e-06" substanceUnits="substance" hasOnlySubstanceUnits="true" boundaryCondition="true" constant="false"/>
     </listOfSpecies>
     <listOfParameters>
       <parameter id="k1" name="k1" value="9.8" constant="true"/>

--- a/cases/semantic/00242/00242-sbml-l3v1.xml
+++ b/cases/semantic/00242/00242-sbml-l3v1.xml
@@ -17,9 +17,9 @@
       <compartment id="compartment" name="compartment" spatialDimensions="0" constant="true"/>
     </listOfCompartments>
     <listOfSpecies>
-      <species id="S1" name="S1" compartment="compartment" initialAmount="1e-006" substanceUnits="substance" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
-      <species id="S2" name="S2" compartment="compartment" initialAmount="2e-006" substanceUnits="substance" hasOnlySubstanceUnits="false" boundaryCondition="true" constant="false"/>
-      <species id="S3" name="S3" compartment="compartment" initialAmount="1e-006" substanceUnits="substance" hasOnlySubstanceUnits="false" boundaryCondition="true" constant="false"/>
+      <species id="S1" name="S1" compartment="compartment" initialAmount="1e-006" substanceUnits="substance" hasOnlySubstanceUnits="true" boundaryCondition="false" constant="false"/>
+      <species id="S2" name="S2" compartment="compartment" initialAmount="2e-006" substanceUnits="substance" hasOnlySubstanceUnits="true" boundaryCondition="true" constant="false"/>
+      <species id="S3" name="S3" compartment="compartment" initialAmount="1e-006" substanceUnits="substance" hasOnlySubstanceUnits="true" boundaryCondition="true" constant="false"/>
     </listOfSpecies>
     <listOfParameters>
       <parameter id="k1" name="k1" value="9.8" constant="true"/>

--- a/cases/semantic/00242/00242-sbml-l3v2.xml
+++ b/cases/semantic/00242/00242-sbml-l3v2.xml
@@ -17,9 +17,9 @@
       <compartment id="compartment" name="compartment" spatialDimensions="0" constant="true"/>
     </listOfCompartments>
     <listOfSpecies>
-      <species id="S1" name="S1" compartment="compartment" initialAmount="1e-06" substanceUnits="substance" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
-      <species id="S2" name="S2" compartment="compartment" initialAmount="2e-06" substanceUnits="substance" hasOnlySubstanceUnits="false" boundaryCondition="true" constant="false"/>
-      <species id="S3" name="S3" compartment="compartment" initialAmount="1e-06" substanceUnits="substance" hasOnlySubstanceUnits="false" boundaryCondition="true" constant="false"/>
+      <species id="S1" name="S1" compartment="compartment" initialAmount="1e-06" substanceUnits="substance" hasOnlySubstanceUnits="true" boundaryCondition="false" constant="false"/>
+      <species id="S2" name="S2" compartment="compartment" initialAmount="2e-06" substanceUnits="substance" hasOnlySubstanceUnits="true" boundaryCondition="true" constant="false"/>
+      <species id="S3" name="S3" compartment="compartment" initialAmount="1e-06" substanceUnits="substance" hasOnlySubstanceUnits="true" boundaryCondition="true" constant="false"/>
     </listOfSpecies>
     <listOfParameters>
       <parameter id="k1" name="k1" value="9.8" constant="true"/>

--- a/cases/semantic/00243/00243-sbml-l3v1.xml
+++ b/cases/semantic/00243/00243-sbml-l3v1.xml
@@ -17,10 +17,10 @@
       <compartment id="compartment" name="compartment" spatialDimensions="0" constant="true"/>
     </listOfCompartments>
     <listOfSpecies>
-      <species id="S1" name="S1" compartment="compartment" initialAmount="1" substanceUnits="substance" hasOnlySubstanceUnits="false" boundaryCondition="true" constant="false"/>
-      <species id="S2" name="S2" compartment="compartment" initialAmount="1.5" substanceUnits="substance" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
-      <species id="S3" name="S3" compartment="compartment" initialAmount="2" substanceUnits="substance" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
-      <species id="S4" name="S4" compartment="compartment" initialAmount="0.5" substanceUnits="substance" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
+      <species id="S1" name="S1" compartment="compartment" initialAmount="1" substanceUnits="substance" hasOnlySubstanceUnits="true" boundaryCondition="true" constant="false"/>
+      <species id="S2" name="S2" compartment="compartment" initialAmount="1.5" substanceUnits="substance" hasOnlySubstanceUnits="true" boundaryCondition="false" constant="false"/>
+      <species id="S3" name="S3" compartment="compartment" initialAmount="2" substanceUnits="substance" hasOnlySubstanceUnits="true" boundaryCondition="false" constant="false"/>
+      <species id="S4" name="S4" compartment="compartment" initialAmount="0.5" substanceUnits="substance" hasOnlySubstanceUnits="true" boundaryCondition="false" constant="false"/>
     </listOfSpecies>
     <listOfParameters>
       <parameter id="k1" name="k1" value="0.6" constant="true"/>

--- a/cases/semantic/00243/00243-sbml-l3v2.xml
+++ b/cases/semantic/00243/00243-sbml-l3v2.xml
@@ -17,10 +17,10 @@
       <compartment id="compartment" name="compartment" spatialDimensions="0" constant="true"/>
     </listOfCompartments>
     <listOfSpecies>
-      <species id="S1" name="S1" compartment="compartment" initialAmount="1" substanceUnits="substance" hasOnlySubstanceUnits="false" boundaryCondition="true" constant="false"/>
-      <species id="S2" name="S2" compartment="compartment" initialAmount="1.5" substanceUnits="substance" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
-      <species id="S3" name="S3" compartment="compartment" initialAmount="2" substanceUnits="substance" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
-      <species id="S4" name="S4" compartment="compartment" initialAmount="0.5" substanceUnits="substance" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
+      <species id="S1" name="S1" compartment="compartment" initialAmount="1" substanceUnits="substance" hasOnlySubstanceUnits="true" boundaryCondition="true" constant="false"/>
+      <species id="S2" name="S2" compartment="compartment" initialAmount="1.5" substanceUnits="substance" hasOnlySubstanceUnits="true" boundaryCondition="false" constant="false"/>
+      <species id="S3" name="S3" compartment="compartment" initialAmount="2" substanceUnits="substance" hasOnlySubstanceUnits="true" boundaryCondition="false" constant="false"/>
+      <species id="S4" name="S4" compartment="compartment" initialAmount="0.5" substanceUnits="substance" hasOnlySubstanceUnits="true" boundaryCondition="false" constant="false"/>
     </listOfSpecies>
     <listOfParameters>
       <parameter id="k1" name="k1" value="0.6" constant="true"/>

--- a/cases/semantic/00244/00244-sbml-l3v1.xml
+++ b/cases/semantic/00244/00244-sbml-l3v1.xml
@@ -17,10 +17,10 @@
       <compartment id="compartment" name="compartment" spatialDimensions="0" constant="true"/>
     </listOfCompartments>
     <listOfSpecies>
-      <species id="S1" name="S1" compartment="compartment" initialAmount="1" substanceUnits="substance" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
-      <species id="S2" name="S2" compartment="compartment" initialAmount="1.5" substanceUnits="substance" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
-      <species id="S3" name="S3" compartment="compartment" initialAmount="2" substanceUnits="substance" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
-      <species id="S4" name="S4" compartment="compartment" initialAmount="0.5" substanceUnits="substance" hasOnlySubstanceUnits="false" boundaryCondition="true" constant="false"/>
+      <species id="S1" name="S1" compartment="compartment" initialAmount="1" substanceUnits="substance" hasOnlySubstanceUnits="true" boundaryCondition="false" constant="false"/>
+      <species id="S2" name="S2" compartment="compartment" initialAmount="1.5" substanceUnits="substance" hasOnlySubstanceUnits="true" boundaryCondition="false" constant="false"/>
+      <species id="S3" name="S3" compartment="compartment" initialAmount="2" substanceUnits="substance" hasOnlySubstanceUnits="true" boundaryCondition="false" constant="false"/>
+      <species id="S4" name="S4" compartment="compartment" initialAmount="0.5" substanceUnits="substance" hasOnlySubstanceUnits="true" boundaryCondition="true" constant="false"/>
     </listOfSpecies>
     <listOfParameters>
       <parameter id="k1" name="k1" value="0.6" constant="true"/>

--- a/cases/semantic/00244/00244-sbml-l3v2.xml
+++ b/cases/semantic/00244/00244-sbml-l3v2.xml
@@ -17,10 +17,10 @@
       <compartment id="compartment" name="compartment" spatialDimensions="0" constant="true"/>
     </listOfCompartments>
     <listOfSpecies>
-      <species id="S1" name="S1" compartment="compartment" initialAmount="1" substanceUnits="substance" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
-      <species id="S2" name="S2" compartment="compartment" initialAmount="1.5" substanceUnits="substance" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
-      <species id="S3" name="S3" compartment="compartment" initialAmount="2" substanceUnits="substance" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
-      <species id="S4" name="S4" compartment="compartment" initialAmount="0.5" substanceUnits="substance" hasOnlySubstanceUnits="false" boundaryCondition="true" constant="false"/>
+      <species id="S1" name="S1" compartment="compartment" initialAmount="1" substanceUnits="substance" hasOnlySubstanceUnits="true" boundaryCondition="false" constant="false"/>
+      <species id="S2" name="S2" compartment="compartment" initialAmount="1.5" substanceUnits="substance" hasOnlySubstanceUnits="true" boundaryCondition="false" constant="false"/>
+      <species id="S3" name="S3" compartment="compartment" initialAmount="2" substanceUnits="substance" hasOnlySubstanceUnits="true" boundaryCondition="false" constant="false"/>
+      <species id="S4" name="S4" compartment="compartment" initialAmount="0.5" substanceUnits="substance" hasOnlySubstanceUnits="true" boundaryCondition="true" constant="false"/>
     </listOfSpecies>
     <listOfParameters>
       <parameter id="k1" name="k1" value="0.6" constant="true"/>

--- a/cases/semantic/00245/00245-sbml-l3v1.xml
+++ b/cases/semantic/00245/00245-sbml-l3v1.xml
@@ -17,10 +17,10 @@
       <compartment id="compartment" name="compartment" spatialDimensions="0" constant="true"/>
     </listOfCompartments>
     <listOfSpecies>
-      <species id="S1" name="S1" compartment="compartment" initialAmount="1" substanceUnits="substance" hasOnlySubstanceUnits="false" boundaryCondition="true" constant="false"/>
-      <species id="S2" name="S2" compartment="compartment" initialAmount="1.5" substanceUnits="substance" hasOnlySubstanceUnits="false" boundaryCondition="true" constant="false"/>
-      <species id="S3" name="S3" compartment="compartment" initialAmount="2" substanceUnits="substance" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
-      <species id="S4" name="S4" compartment="compartment" initialAmount="0.5" substanceUnits="substance" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
+      <species id="S1" name="S1" compartment="compartment" initialAmount="1" substanceUnits="substance" hasOnlySubstanceUnits="true" boundaryCondition="true" constant="false"/>
+      <species id="S2" name="S2" compartment="compartment" initialAmount="1.5" substanceUnits="substance" hasOnlySubstanceUnits="true" boundaryCondition="true" constant="false"/>
+      <species id="S3" name="S3" compartment="compartment" initialAmount="2" substanceUnits="substance" hasOnlySubstanceUnits="true" boundaryCondition="false" constant="false"/>
+      <species id="S4" name="S4" compartment="compartment" initialAmount="0.5" substanceUnits="substance" hasOnlySubstanceUnits="true" boundaryCondition="false" constant="false"/>
     </listOfSpecies>
     <listOfParameters>
       <parameter id="k1" name="k1" value="0.6" constant="true"/>

--- a/cases/semantic/00245/00245-sbml-l3v2.xml
+++ b/cases/semantic/00245/00245-sbml-l3v2.xml
@@ -17,10 +17,10 @@
       <compartment id="compartment" name="compartment" spatialDimensions="0" constant="true"/>
     </listOfCompartments>
     <listOfSpecies>
-      <species id="S1" name="S1" compartment="compartment" initialAmount="1" substanceUnits="substance" hasOnlySubstanceUnits="false" boundaryCondition="true" constant="false"/>
-      <species id="S2" name="S2" compartment="compartment" initialAmount="1.5" substanceUnits="substance" hasOnlySubstanceUnits="false" boundaryCondition="true" constant="false"/>
-      <species id="S3" name="S3" compartment="compartment" initialAmount="2" substanceUnits="substance" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
-      <species id="S4" name="S4" compartment="compartment" initialAmount="0.5" substanceUnits="substance" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
+      <species id="S1" name="S1" compartment="compartment" initialAmount="1" substanceUnits="substance" hasOnlySubstanceUnits="true" boundaryCondition="true" constant="false"/>
+      <species id="S2" name="S2" compartment="compartment" initialAmount="1.5" substanceUnits="substance" hasOnlySubstanceUnits="true" boundaryCondition="true" constant="false"/>
+      <species id="S3" name="S3" compartment="compartment" initialAmount="2" substanceUnits="substance" hasOnlySubstanceUnits="true" boundaryCondition="false" constant="false"/>
+      <species id="S4" name="S4" compartment="compartment" initialAmount="0.5" substanceUnits="substance" hasOnlySubstanceUnits="true" boundaryCondition="false" constant="false"/>
     </listOfSpecies>
     <listOfParameters>
       <parameter id="k1" name="k1" value="0.6" constant="true"/>

--- a/cases/semantic/00246/00246-sbml-l3v1.xml
+++ b/cases/semantic/00246/00246-sbml-l3v1.xml
@@ -17,10 +17,10 @@
       <compartment id="compartment" name="compartment" spatialDimensions="0" constant="true"/>
     </listOfCompartments>
     <listOfSpecies>
-      <species id="S1" name="S1" compartment="compartment" initialAmount="1" substanceUnits="substance" hasOnlySubstanceUnits="false" boundaryCondition="true" constant="false"/>
-      <species id="S2" name="S2" compartment="compartment" initialAmount="1.5" substanceUnits="substance" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
-      <species id="S3" name="S3" compartment="compartment" initialAmount="2" substanceUnits="substance" hasOnlySubstanceUnits="false" boundaryCondition="true" constant="false"/>
-      <species id="S4" name="S4" compartment="compartment" initialAmount="0.5" substanceUnits="substance" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
+      <species id="S1" name="S1" compartment="compartment" initialAmount="1" substanceUnits="substance" hasOnlySubstanceUnits="true" boundaryCondition="true" constant="false"/>
+      <species id="S2" name="S2" compartment="compartment" initialAmount="1.5" substanceUnits="substance" hasOnlySubstanceUnits="true" boundaryCondition="false" constant="false"/>
+      <species id="S3" name="S3" compartment="compartment" initialAmount="2" substanceUnits="substance" hasOnlySubstanceUnits="true" boundaryCondition="true" constant="false"/>
+      <species id="S4" name="S4" compartment="compartment" initialAmount="0.5" substanceUnits="substance" hasOnlySubstanceUnits="true" boundaryCondition="false" constant="false"/>
     </listOfSpecies>
     <listOfParameters>
       <parameter id="k1" name="k1" value="0.6" constant="true"/>

--- a/cases/semantic/00246/00246-sbml-l3v2.xml
+++ b/cases/semantic/00246/00246-sbml-l3v2.xml
@@ -17,10 +17,10 @@
       <compartment id="compartment" name="compartment" spatialDimensions="0" constant="true"/>
     </listOfCompartments>
     <listOfSpecies>
-      <species id="S1" name="S1" compartment="compartment" initialAmount="1" substanceUnits="substance" hasOnlySubstanceUnits="false" boundaryCondition="true" constant="false"/>
-      <species id="S2" name="S2" compartment="compartment" initialAmount="1.5" substanceUnits="substance" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
-      <species id="S3" name="S3" compartment="compartment" initialAmount="2" substanceUnits="substance" hasOnlySubstanceUnits="false" boundaryCondition="true" constant="false"/>
-      <species id="S4" name="S4" compartment="compartment" initialAmount="0.5" substanceUnits="substance" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
+      <species id="S1" name="S1" compartment="compartment" initialAmount="1" substanceUnits="substance" hasOnlySubstanceUnits="true" boundaryCondition="true" constant="false"/>
+      <species id="S2" name="S2" compartment="compartment" initialAmount="1.5" substanceUnits="substance" hasOnlySubstanceUnits="true" boundaryCondition="false" constant="false"/>
+      <species id="S3" name="S3" compartment="compartment" initialAmount="2" substanceUnits="substance" hasOnlySubstanceUnits="true" boundaryCondition="true" constant="false"/>
+      <species id="S4" name="S4" compartment="compartment" initialAmount="0.5" substanceUnits="substance" hasOnlySubstanceUnits="true" boundaryCondition="false" constant="false"/>
     </listOfSpecies>
     <listOfParameters>
       <parameter id="k1" name="k1" value="0.6" constant="true"/>

--- a/cases/semantic/00247/00247-sbml-l3v1.xml
+++ b/cases/semantic/00247/00247-sbml-l3v1.xml
@@ -17,10 +17,10 @@
       <compartment id="compartment" name="compartment" spatialDimensions="0" constant="true"/>
     </listOfCompartments>
     <listOfSpecies>
-      <species id="S1" name="S1" compartment="compartment" initialAmount="1" substanceUnits="substance" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
-      <species id="S2" name="S2" compartment="compartment" initialAmount="1.5" substanceUnits="substance" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
-      <species id="S3" name="S3" compartment="compartment" initialAmount="2" substanceUnits="substance" hasOnlySubstanceUnits="false" boundaryCondition="true" constant="false"/>
-      <species id="S4" name="S4" compartment="compartment" initialAmount="0.5" substanceUnits="substance" hasOnlySubstanceUnits="false" boundaryCondition="true" constant="false"/>
+      <species id="S1" name="S1" compartment="compartment" initialAmount="1" substanceUnits="substance" hasOnlySubstanceUnits="true" boundaryCondition="false" constant="false"/>
+      <species id="S2" name="S2" compartment="compartment" initialAmount="1.5" substanceUnits="substance" hasOnlySubstanceUnits="true" boundaryCondition="false" constant="false"/>
+      <species id="S3" name="S3" compartment="compartment" initialAmount="2" substanceUnits="substance" hasOnlySubstanceUnits="true" boundaryCondition="true" constant="false"/>
+      <species id="S4" name="S4" compartment="compartment" initialAmount="0.5" substanceUnits="substance" hasOnlySubstanceUnits="true" boundaryCondition="true" constant="false"/>
     </listOfSpecies>
     <listOfParameters>
       <parameter id="k1" name="k1" value="0.6" constant="true"/>

--- a/cases/semantic/00247/00247-sbml-l3v2.xml
+++ b/cases/semantic/00247/00247-sbml-l3v2.xml
@@ -17,10 +17,10 @@
       <compartment id="compartment" name="compartment" spatialDimensions="0" constant="true"/>
     </listOfCompartments>
     <listOfSpecies>
-      <species id="S1" name="S1" compartment="compartment" initialAmount="1" substanceUnits="substance" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
-      <species id="S2" name="S2" compartment="compartment" initialAmount="1.5" substanceUnits="substance" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
-      <species id="S3" name="S3" compartment="compartment" initialAmount="2" substanceUnits="substance" hasOnlySubstanceUnits="false" boundaryCondition="true" constant="false"/>
-      <species id="S4" name="S4" compartment="compartment" initialAmount="0.5" substanceUnits="substance" hasOnlySubstanceUnits="false" boundaryCondition="true" constant="false"/>
+      <species id="S1" name="S1" compartment="compartment" initialAmount="1" substanceUnits="substance" hasOnlySubstanceUnits="true" boundaryCondition="false" constant="false"/>
+      <species id="S2" name="S2" compartment="compartment" initialAmount="1.5" substanceUnits="substance" hasOnlySubstanceUnits="true" boundaryCondition="false" constant="false"/>
+      <species id="S3" name="S3" compartment="compartment" initialAmount="2" substanceUnits="substance" hasOnlySubstanceUnits="true" boundaryCondition="true" constant="false"/>
+      <species id="S4" name="S4" compartment="compartment" initialAmount="0.5" substanceUnits="substance" hasOnlySubstanceUnits="true" boundaryCondition="true" constant="false"/>
     </listOfSpecies>
     <listOfParameters>
       <parameter id="k1" name="k1" value="0.6" constant="true"/>

--- a/cases/semantic/00257/00257-sbml-l3v1.xml
+++ b/cases/semantic/00257/00257-sbml-l3v1.xml
@@ -17,9 +17,9 @@
       <compartment id="compartment" name="compartment" spatialDimensions="0" constant="true"/>
     </listOfCompartments>
     <listOfSpecies>
-      <species id="S1" name="S1" compartment="compartment" initialAmount="1.5" substanceUnits="substance" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
-      <species id="S2" name="S2" compartment="compartment" initialAmount="0.5" substanceUnits="substance" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
-      <species id="S3" name="S3" compartment="compartment" initialAmount="1.2" substanceUnits="substance" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="true"/>
+      <species id="S1" name="S1" compartment="compartment" initialAmount="1.5" substanceUnits="substance" hasOnlySubstanceUnits="true" boundaryCondition="false" constant="false"/>
+      <species id="S2" name="S2" compartment="compartment" initialAmount="0.5" substanceUnits="substance" hasOnlySubstanceUnits="true" boundaryCondition="false" constant="false"/>
+      <species id="S3" name="S3" compartment="compartment" initialAmount="1.2" substanceUnits="substance" hasOnlySubstanceUnits="true" boundaryCondition="false" constant="true"/>
     </listOfSpecies>
     <listOfParameters>
       <parameter id="k1" name="k1" value="1.78" constant="true"/>

--- a/cases/semantic/00257/00257-sbml-l3v2.xml
+++ b/cases/semantic/00257/00257-sbml-l3v2.xml
@@ -17,9 +17,9 @@
       <compartment id="compartment" name="compartment" spatialDimensions="0" constant="true"/>
     </listOfCompartments>
     <listOfSpecies>
-      <species id="S1" name="S1" compartment="compartment" initialAmount="1.5" substanceUnits="substance" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
-      <species id="S2" name="S2" compartment="compartment" initialAmount="0.5" substanceUnits="substance" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
-      <species id="S3" name="S3" compartment="compartment" initialAmount="1.2" substanceUnits="substance" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="true"/>
+      <species id="S1" name="S1" compartment="compartment" initialAmount="1.5" substanceUnits="substance" hasOnlySubstanceUnits="true" boundaryCondition="false" constant="false"/>
+      <species id="S2" name="S2" compartment="compartment" initialAmount="0.5" substanceUnits="substance" hasOnlySubstanceUnits="true" boundaryCondition="false" constant="false"/>
+      <species id="S3" name="S3" compartment="compartment" initialAmount="1.2" substanceUnits="substance" hasOnlySubstanceUnits="true" boundaryCondition="false" constant="true"/>
     </listOfSpecies>
     <listOfParameters>
       <parameter id="k1" name="k1" value="1.78" constant="true"/>

--- a/cases/semantic/00258/00258-sbml-l3v1.xml
+++ b/cases/semantic/00258/00258-sbml-l3v1.xml
@@ -17,10 +17,10 @@
       <compartment id="compartment" name="compartment" spatialDimensions="0" constant="true"/>
     </listOfCompartments>
     <listOfSpecies>
-      <species id="S1" name="S1" compartment="compartment" initialAmount="0.001" substanceUnits="substance" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
-      <species id="S2" name="S2" compartment="compartment" initialAmount="0.0015" substanceUnits="substance" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
-      <species id="S3" name="S3" compartment="compartment" initialAmount="0.00075" substanceUnits="substance" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
-      <species id="S4" name="S4" compartment="compartment" initialAmount="0.00125" substanceUnits="substance" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="true"/>
+      <species id="S1" name="S1" compartment="compartment" initialAmount="0.001" substanceUnits="substance" hasOnlySubstanceUnits="true" boundaryCondition="false" constant="false"/>
+      <species id="S2" name="S2" compartment="compartment" initialAmount="0.0015" substanceUnits="substance" hasOnlySubstanceUnits="true" boundaryCondition="false" constant="false"/>
+      <species id="S3" name="S3" compartment="compartment" initialAmount="0.00075" substanceUnits="substance" hasOnlySubstanceUnits="true" boundaryCondition="false" constant="false"/>
+      <species id="S4" name="S4" compartment="compartment" initialAmount="0.00125" substanceUnits="substance" hasOnlySubstanceUnits="true" boundaryCondition="false" constant="true"/>
     </listOfSpecies>
     <listOfParameters>
       <parameter id="k1" name="k1" value="1680" constant="true"/>

--- a/cases/semantic/00258/00258-sbml-l3v2.xml
+++ b/cases/semantic/00258/00258-sbml-l3v2.xml
@@ -17,10 +17,10 @@
       <compartment id="compartment" name="compartment" spatialDimensions="0" constant="true"/>
     </listOfCompartments>
     <listOfSpecies>
-      <species id="S1" name="S1" compartment="compartment" initialAmount="0.001" substanceUnits="substance" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
-      <species id="S2" name="S2" compartment="compartment" initialAmount="0.0015" substanceUnits="substance" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
-      <species id="S3" name="S3" compartment="compartment" initialAmount="0.00075" substanceUnits="substance" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
-      <species id="S4" name="S4" compartment="compartment" initialAmount="0.00125" substanceUnits="substance" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="true"/>
+      <species id="S1" name="S1" compartment="compartment" initialAmount="0.001" substanceUnits="substance" hasOnlySubstanceUnits="true" boundaryCondition="false" constant="false"/>
+      <species id="S2" name="S2" compartment="compartment" initialAmount="0.0015" substanceUnits="substance" hasOnlySubstanceUnits="true" boundaryCondition="false" constant="false"/>
+      <species id="S3" name="S3" compartment="compartment" initialAmount="0.00075" substanceUnits="substance" hasOnlySubstanceUnits="true" boundaryCondition="false" constant="false"/>
+      <species id="S4" name="S4" compartment="compartment" initialAmount="0.00125" substanceUnits="substance" hasOnlySubstanceUnits="true" boundaryCondition="false" constant="true"/>
     </listOfSpecies>
     <listOfParameters>
       <parameter id="k1" name="k1" value="1680" constant="true"/>

--- a/cases/semantic/00259/00259-sbml-l3v1.xml
+++ b/cases/semantic/00259/00259-sbml-l3v1.xml
@@ -17,11 +17,11 @@
       <compartment id="compartment" name="compartment" spatialDimensions="0" constant="true"/>
     </listOfCompartments>
     <listOfSpecies>
-      <species id="S1" name="S1" compartment="compartment" initialAmount="1e-006" substanceUnits="substance" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
-      <species id="S2" name="S2" compartment="compartment" initialAmount="1.5e-006" substanceUnits="substance" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
-      <species id="S3" name="S3" compartment="compartment" initialAmount="2e-006" substanceUnits="substance" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
-      <species id="S4" name="S4" compartment="compartment" initialAmount="5e-007" substanceUnits="substance" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
-      <species id="S5" name="S5" compartment="compartment" initialAmount="1e-006" substanceUnits="substance" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="true"/>
+      <species id="S1" name="S1" compartment="compartment" initialAmount="1e-006" substanceUnits="substance" hasOnlySubstanceUnits="true" boundaryCondition="false" constant="false"/>
+      <species id="S2" name="S2" compartment="compartment" initialAmount="1.5e-006" substanceUnits="substance" hasOnlySubstanceUnits="true" boundaryCondition="false" constant="false"/>
+      <species id="S3" name="S3" compartment="compartment" initialAmount="2e-006" substanceUnits="substance" hasOnlySubstanceUnits="true" boundaryCondition="false" constant="false"/>
+      <species id="S4" name="S4" compartment="compartment" initialAmount="5e-007" substanceUnits="substance" hasOnlySubstanceUnits="true" boundaryCondition="false" constant="false"/>
+      <species id="S5" name="S5" compartment="compartment" initialAmount="1e-006" substanceUnits="substance" hasOnlySubstanceUnits="true" boundaryCondition="false" constant="true"/>
     </listOfSpecies>
     <listOfParameters>
       <parameter id="k1" name="k1" value="1300000" constant="true"/>

--- a/cases/semantic/00259/00259-sbml-l3v2.xml
+++ b/cases/semantic/00259/00259-sbml-l3v2.xml
@@ -17,11 +17,11 @@
       <compartment id="compartment" name="compartment" spatialDimensions="0" constant="true"/>
     </listOfCompartments>
     <listOfSpecies>
-      <species id="S1" name="S1" compartment="compartment" initialAmount="1e-06" substanceUnits="substance" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
-      <species id="S2" name="S2" compartment="compartment" initialAmount="1.5e-06" substanceUnits="substance" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
-      <species id="S3" name="S3" compartment="compartment" initialAmount="2e-06" substanceUnits="substance" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
-      <species id="S4" name="S4" compartment="compartment" initialAmount="5e-07" substanceUnits="substance" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
-      <species id="S5" name="S5" compartment="compartment" initialAmount="1e-06" substanceUnits="substance" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="true"/>
+      <species id="S1" name="S1" compartment="compartment" initialAmount="1e-06" substanceUnits="substance" hasOnlySubstanceUnits="true" boundaryCondition="false" constant="false"/>
+      <species id="S2" name="S2" compartment="compartment" initialAmount="1.5e-06" substanceUnits="substance" hasOnlySubstanceUnits="true" boundaryCondition="false" constant="false"/>
+      <species id="S3" name="S3" compartment="compartment" initialAmount="2e-06" substanceUnits="substance" hasOnlySubstanceUnits="true" boundaryCondition="false" constant="false"/>
+      <species id="S4" name="S4" compartment="compartment" initialAmount="5e-07" substanceUnits="substance" hasOnlySubstanceUnits="true" boundaryCondition="false" constant="false"/>
+      <species id="S5" name="S5" compartment="compartment" initialAmount="1e-06" substanceUnits="substance" hasOnlySubstanceUnits="true" boundaryCondition="false" constant="true"/>
     </listOfSpecies>
     <listOfParameters>
       <parameter id="k1" name="k1" value="1300000" constant="true"/>

--- a/cases/semantic/00262/00262-sbml-l3v1.xml
+++ b/cases/semantic/00262/00262-sbml-l3v1.xml
@@ -17,8 +17,8 @@
       <compartment id="compartment" name="compartment" spatialDimensions="0" constant="true"/>
     </listOfCompartments>
     <listOfSpecies>
-      <species id="S1" name="S1" compartment="compartment" initialAmount="0.00015" substanceUnits="substance" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
-      <species id="S2" name="S2" compartment="compartment" initialAmount="0" substanceUnits="substance" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
+      <species id="S1" name="S1" compartment="compartment" initialAmount="0.00015" substanceUnits="substance" hasOnlySubstanceUnits="true" boundaryCondition="false" constant="false"/>
+      <species id="S2" name="S2" compartment="compartment" initialAmount="0" substanceUnits="substance" hasOnlySubstanceUnits="true" boundaryCondition="false" constant="false"/>
     </listOfSpecies>
     <listOfParameters>
       <parameter id="k1" name="k1" value="0.35" constant="true"/>

--- a/cases/semantic/00262/00262-sbml-l3v2.xml
+++ b/cases/semantic/00262/00262-sbml-l3v2.xml
@@ -17,8 +17,8 @@
       <compartment id="compartment" name="compartment" spatialDimensions="0" constant="true"/>
     </listOfCompartments>
     <listOfSpecies>
-      <species id="S1" name="S1" compartment="compartment" initialAmount="0.00015" substanceUnits="substance" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
-      <species id="S2" name="S2" compartment="compartment" initialAmount="0" substanceUnits="substance" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
+      <species id="S1" name="S1" compartment="compartment" initialAmount="0.00015" substanceUnits="substance" hasOnlySubstanceUnits="true" boundaryCondition="false" constant="false"/>
+      <species id="S2" name="S2" compartment="compartment" initialAmount="0" substanceUnits="substance" hasOnlySubstanceUnits="true" boundaryCondition="false" constant="false"/>
     </listOfSpecies>
     <listOfParameters>
       <parameter id="k1" name="k1" value="0.35" constant="true"/>

--- a/cases/semantic/00265/00265-sbml-l3v1.xml
+++ b/cases/semantic/00265/00265-sbml-l3v1.xml
@@ -17,9 +17,9 @@
       <compartment id="compartment" name="compartment" spatialDimensions="0" constant="true"/>
     </listOfCompartments>
     <listOfSpecies>
-      <species id="S1" name="S1" compartment="compartment" initialAmount="0.01" substanceUnits="substance" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
-      <species id="S2" name="S2" compartment="compartment" initialAmount="0.005" substanceUnits="substance" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
-      <species id="S3" name="S3" compartment="compartment" initialAmount="0.01" substanceUnits="substance" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
+      <species id="S1" name="S1" compartment="compartment" initialAmount="0.01" substanceUnits="substance" hasOnlySubstanceUnits="true" boundaryCondition="false" constant="false"/>
+      <species id="S2" name="S2" compartment="compartment" initialAmount="0.005" substanceUnits="substance" hasOnlySubstanceUnits="true" boundaryCondition="false" constant="false"/>
+      <species id="S3" name="S3" compartment="compartment" initialAmount="0.01" substanceUnits="substance" hasOnlySubstanceUnits="true" boundaryCondition="false" constant="false"/>
     </listOfSpecies>
     <listOfParameters>
       <parameter id="k1" name="k1" value="160" constant="true"/>

--- a/cases/semantic/00265/00265-sbml-l3v2.xml
+++ b/cases/semantic/00265/00265-sbml-l3v2.xml
@@ -17,9 +17,9 @@
       <compartment id="compartment" name="compartment" spatialDimensions="0" constant="true"/>
     </listOfCompartments>
     <listOfSpecies>
-      <species id="S1" name="S1" compartment="compartment" initialAmount="0.01" substanceUnits="substance" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
-      <species id="S2" name="S2" compartment="compartment" initialAmount="0.005" substanceUnits="substance" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
-      <species id="S3" name="S3" compartment="compartment" initialAmount="0.01" substanceUnits="substance" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
+      <species id="S1" name="S1" compartment="compartment" initialAmount="0.01" substanceUnits="substance" hasOnlySubstanceUnits="true" boundaryCondition="false" constant="false"/>
+      <species id="S2" name="S2" compartment="compartment" initialAmount="0.005" substanceUnits="substance" hasOnlySubstanceUnits="true" boundaryCondition="false" constant="false"/>
+      <species id="S3" name="S3" compartment="compartment" initialAmount="0.01" substanceUnits="substance" hasOnlySubstanceUnits="true" boundaryCondition="false" constant="false"/>
     </listOfSpecies>
     <listOfParameters>
       <parameter id="k1" name="k1" value="160" constant="true"/>

--- a/cases/semantic/00268/00268-sbml-l3v1.xml
+++ b/cases/semantic/00268/00268-sbml-l3v1.xml
@@ -17,10 +17,10 @@
       <compartment id="compartment" name="compartment" spatialDimensions="0" constant="true"/>
     </listOfCompartments>
     <listOfSpecies>
-      <species id="S1" name="S1" compartment="compartment" initialAmount="1e-006" substanceUnits="substance" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
-      <species id="S2" name="S2" compartment="compartment" initialAmount="5e-007" substanceUnits="substance" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
-      <species id="S3" name="S3" compartment="compartment" initialAmount="2e-006" substanceUnits="substance" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
-      <species id="S4" name="S4" compartment="compartment" initialAmount="0" substanceUnits="substance" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
+      <species id="S1" name="S1" compartment="compartment" initialAmount="1e-006" substanceUnits="substance" hasOnlySubstanceUnits="true" boundaryCondition="false" constant="false"/>
+      <species id="S2" name="S2" compartment="compartment" initialAmount="5e-007" substanceUnits="substance" hasOnlySubstanceUnits="true" boundaryCondition="false" constant="false"/>
+      <species id="S3" name="S3" compartment="compartment" initialAmount="2e-006" substanceUnits="substance" hasOnlySubstanceUnits="true" boundaryCondition="false" constant="false"/>
+      <species id="S4" name="S4" compartment="compartment" initialAmount="0" substanceUnits="substance" hasOnlySubstanceUnits="true" boundaryCondition="false" constant="false"/>
     </listOfSpecies>
     <listOfParameters>
       <parameter id="k1" name="k1" value="900000" constant="true"/>

--- a/cases/semantic/00268/00268-sbml-l3v2.xml
+++ b/cases/semantic/00268/00268-sbml-l3v2.xml
@@ -17,10 +17,10 @@
       <compartment id="compartment" name="compartment" spatialDimensions="0" constant="true"/>
     </listOfCompartments>
     <listOfSpecies>
-      <species id="S1" name="S1" compartment="compartment" initialAmount="1e-06" substanceUnits="substance" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
-      <species id="S2" name="S2" compartment="compartment" initialAmount="5e-07" substanceUnits="substance" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
-      <species id="S3" name="S3" compartment="compartment" initialAmount="2e-06" substanceUnits="substance" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
-      <species id="S4" name="S4" compartment="compartment" initialAmount="0" substanceUnits="substance" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
+      <species id="S1" name="S1" compartment="compartment" initialAmount="1e-06" substanceUnits="substance" hasOnlySubstanceUnits="true" boundaryCondition="false" constant="false"/>
+      <species id="S2" name="S2" compartment="compartment" initialAmount="5e-07" substanceUnits="substance" hasOnlySubstanceUnits="true" boundaryCondition="false" constant="false"/>
+      <species id="S3" name="S3" compartment="compartment" initialAmount="2e-06" substanceUnits="substance" hasOnlySubstanceUnits="true" boundaryCondition="false" constant="false"/>
+      <species id="S4" name="S4" compartment="compartment" initialAmount="0" substanceUnits="substance" hasOnlySubstanceUnits="true" boundaryCondition="false" constant="false"/>
     </listOfSpecies>
     <listOfParameters>
       <parameter id="k1" name="k1" value="900000" constant="true"/>

--- a/cases/semantic/00321/00321-sbml-l3v1.xml
+++ b/cases/semantic/00321/00321-sbml-l3v1.xml
@@ -17,9 +17,9 @@
       <compartment id="compartment" name="compartment" spatialDimensions="0" constant="true"/>
     </listOfCompartments>
     <listOfSpecies>
-      <species id="S1" name="S1" compartment="compartment" initialAmount="1.5" substanceUnits="substance" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
-      <species id="S2" name="S2" compartment="compartment" initialAmount="0" substanceUnits="substance" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
-      <species id="S3" name="S3" compartment="compartment" initialAmount="0" substanceUnits="substance" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
+      <species id="S1" name="S1" compartment="compartment" initialAmount="1.5" substanceUnits="substance" hasOnlySubstanceUnits="true" boundaryCondition="false" constant="false"/>
+      <species id="S2" name="S2" compartment="compartment" initialAmount="0" substanceUnits="substance" hasOnlySubstanceUnits="true" boundaryCondition="false" constant="false"/>
+      <species id="S3" name="S3" compartment="compartment" initialAmount="0" substanceUnits="substance" hasOnlySubstanceUnits="true" boundaryCondition="false" constant="false"/>
     </listOfSpecies>
     <listOfParameters>
       <parameter id="k1" name="k1" value="1.546" constant="true"/>

--- a/cases/semantic/00321/00321-sbml-l3v2.xml
+++ b/cases/semantic/00321/00321-sbml-l3v2.xml
@@ -17,9 +17,9 @@
       <compartment id="compartment" name="compartment" spatialDimensions="0" constant="true"/>
     </listOfCompartments>
     <listOfSpecies>
-      <species id="S1" name="S1" compartment="compartment" initialAmount="1.5" substanceUnits="substance" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
-      <species id="S2" name="S2" compartment="compartment" initialAmount="0" substanceUnits="substance" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
-      <species id="S3" name="S3" compartment="compartment" initialAmount="0" substanceUnits="substance" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
+      <species id="S1" name="S1" compartment="compartment" initialAmount="1.5" substanceUnits="substance" hasOnlySubstanceUnits="true" boundaryCondition="false" constant="false"/>
+      <species id="S2" name="S2" compartment="compartment" initialAmount="0" substanceUnits="substance" hasOnlySubstanceUnits="true" boundaryCondition="false" constant="false"/>
+      <species id="S3" name="S3" compartment="compartment" initialAmount="0" substanceUnits="substance" hasOnlySubstanceUnits="true" boundaryCondition="false" constant="false"/>
     </listOfSpecies>
     <listOfParameters>
       <parameter id="k1" name="k1" value="1.546" constant="true"/>

--- a/cases/semantic/00324/00324-sbml-l3v1.xml
+++ b/cases/semantic/00324/00324-sbml-l3v1.xml
@@ -17,10 +17,10 @@
       <compartment id="compartment" name="compartment" spatialDimensions="0" constant="true"/>
     </listOfCompartments>
     <listOfSpecies>
-      <species id="S1" name="S1" compartment="compartment" initialAmount="0.015" substanceUnits="substance" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
-      <species id="S2" name="S2" compartment="compartment" initialAmount="0.02" substanceUnits="substance" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
-      <species id="S3" name="S3" compartment="compartment" initialAmount="0.04" substanceUnits="substance" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
-      <species id="S4" name="S4" compartment="compartment" initialAmount="0.01" substanceUnits="substance" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
+      <species id="S1" name="S1" compartment="compartment" initialAmount="0.015" substanceUnits="substance" hasOnlySubstanceUnits="true" boundaryCondition="false" constant="false"/>
+      <species id="S2" name="S2" compartment="compartment" initialAmount="0.02" substanceUnits="substance" hasOnlySubstanceUnits="true" boundaryCondition="false" constant="false"/>
+      <species id="S3" name="S3" compartment="compartment" initialAmount="0.04" substanceUnits="substance" hasOnlySubstanceUnits="true" boundaryCondition="false" constant="false"/>
+      <species id="S4" name="S4" compartment="compartment" initialAmount="0.01" substanceUnits="substance" hasOnlySubstanceUnits="true" boundaryCondition="false" constant="false"/>
     </listOfSpecies>
     <listOfParameters>
       <parameter id="k1" name="k1" value="69" constant="true"/>

--- a/cases/semantic/00324/00324-sbml-l3v2.xml
+++ b/cases/semantic/00324/00324-sbml-l3v2.xml
@@ -17,10 +17,10 @@
       <compartment id="compartment" name="compartment" spatialDimensions="0" constant="true"/>
     </listOfCompartments>
     <listOfSpecies>
-      <species id="S1" name="S1" compartment="compartment" initialAmount="0.015" substanceUnits="substance" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
-      <species id="S2" name="S2" compartment="compartment" initialAmount="0.02" substanceUnits="substance" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
-      <species id="S3" name="S3" compartment="compartment" initialAmount="0.04" substanceUnits="substance" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
-      <species id="S4" name="S4" compartment="compartment" initialAmount="0.01" substanceUnits="substance" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
+      <species id="S1" name="S1" compartment="compartment" initialAmount="0.015" substanceUnits="substance" hasOnlySubstanceUnits="true" boundaryCondition="false" constant="false"/>
+      <species id="S2" name="S2" compartment="compartment" initialAmount="0.02" substanceUnits="substance" hasOnlySubstanceUnits="true" boundaryCondition="false" constant="false"/>
+      <species id="S3" name="S3" compartment="compartment" initialAmount="0.04" substanceUnits="substance" hasOnlySubstanceUnits="true" boundaryCondition="false" constant="false"/>
+      <species id="S4" name="S4" compartment="compartment" initialAmount="0.01" substanceUnits="substance" hasOnlySubstanceUnits="true" boundaryCondition="false" constant="false"/>
     </listOfSpecies>
     <listOfParameters>
       <parameter id="k1" name="k1" value="69" constant="true"/>

--- a/cases/semantic/00327/00327-sbml-l3v1.xml
+++ b/cases/semantic/00327/00327-sbml-l3v1.xml
@@ -17,10 +17,10 @@
       <compartment id="compartment" name="compartment" spatialDimensions="0" constant="true"/>
     </listOfCompartments>
     <listOfSpecies>
-      <species id="S1" name="S1" compartment="compartment" initialAmount="1.5" substanceUnits="substance" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
-      <species id="S2" name="S2" compartment="compartment" initialAmount="2" substanceUnits="substance" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
-      <species id="S3" name="S3" compartment="compartment" initialAmount="1.5" substanceUnits="substance" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
-      <species id="S4" name="S4" compartment="compartment" initialAmount="4" substanceUnits="substance" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
+      <species id="S1" name="S1" compartment="compartment" initialAmount="1.5" substanceUnits="substance" hasOnlySubstanceUnits="true" boundaryCondition="false" constant="false"/>
+      <species id="S2" name="S2" compartment="compartment" initialAmount="2" substanceUnits="substance" hasOnlySubstanceUnits="true" boundaryCondition="false" constant="false"/>
+      <species id="S3" name="S3" compartment="compartment" initialAmount="1.5" substanceUnits="substance" hasOnlySubstanceUnits="true" boundaryCondition="false" constant="false"/>
+      <species id="S4" name="S4" compartment="compartment" initialAmount="4" substanceUnits="substance" hasOnlySubstanceUnits="true" boundaryCondition="false" constant="false"/>
     </listOfSpecies>
     <listOfParameters>
       <parameter id="k1" name="k1" value="0.75" constant="true"/>

--- a/cases/semantic/00327/00327-sbml-l3v2.xml
+++ b/cases/semantic/00327/00327-sbml-l3v2.xml
@@ -17,10 +17,10 @@
       <compartment id="compartment" name="compartment" spatialDimensions="0" constant="true"/>
     </listOfCompartments>
     <listOfSpecies>
-      <species id="S1" name="S1" compartment="compartment" initialAmount="1.5" substanceUnits="substance" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
-      <species id="S2" name="S2" compartment="compartment" initialAmount="2" substanceUnits="substance" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
-      <species id="S3" name="S3" compartment="compartment" initialAmount="1.5" substanceUnits="substance" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
-      <species id="S4" name="S4" compartment="compartment" initialAmount="4" substanceUnits="substance" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
+      <species id="S1" name="S1" compartment="compartment" initialAmount="1.5" substanceUnits="substance" hasOnlySubstanceUnits="true" boundaryCondition="false" constant="false"/>
+      <species id="S2" name="S2" compartment="compartment" initialAmount="2" substanceUnits="substance" hasOnlySubstanceUnits="true" boundaryCondition="false" constant="false"/>
+      <species id="S3" name="S3" compartment="compartment" initialAmount="1.5" substanceUnits="substance" hasOnlySubstanceUnits="true" boundaryCondition="false" constant="false"/>
+      <species id="S4" name="S4" compartment="compartment" initialAmount="4" substanceUnits="substance" hasOnlySubstanceUnits="true" boundaryCondition="false" constant="false"/>
     </listOfSpecies>
     <listOfParameters>
       <parameter id="k1" name="k1" value="0.75" constant="true"/>

--- a/cases/semantic/00362/00362-sbml-l3v1.xml
+++ b/cases/semantic/00362/00362-sbml-l3v1.xml
@@ -17,9 +17,9 @@
       <compartment id="C" name="C" spatialDimensions="0" constant="true"/>
     </listOfCompartments>
     <listOfSpecies>
-      <species id="S1" name="S1" compartment="C" initialAmount="1" substanceUnits="substance" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
-      <species id="S2" name="S2" compartment="C" initialAmount="2" substanceUnits="substance" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
-      <species id="S3" name="S3" compartment="C" initialAmount="1" substanceUnits="substance" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
+      <species id="S1" name="S1" compartment="C" initialAmount="1" substanceUnits="substance" hasOnlySubstanceUnits="true" boundaryCondition="false" constant="false"/>
+      <species id="S2" name="S2" compartment="C" initialAmount="2" substanceUnits="substance" hasOnlySubstanceUnits="true" boundaryCondition="false" constant="false"/>
+      <species id="S3" name="S3" compartment="C" initialAmount="1" substanceUnits="substance" hasOnlySubstanceUnits="true" boundaryCondition="false" constant="false"/>
     </listOfSpecies>
     <listOfParameters>
       <parameter id="k1" name="k1" value="0.8" constant="true"/>

--- a/cases/semantic/00362/00362-sbml-l3v2.xml
+++ b/cases/semantic/00362/00362-sbml-l3v2.xml
@@ -17,9 +17,9 @@
       <compartment id="C" name="C" spatialDimensions="0" constant="true"/>
     </listOfCompartments>
     <listOfSpecies>
-      <species id="S1" name="S1" compartment="C" initialAmount="1" substanceUnits="substance" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
-      <species id="S2" name="S2" compartment="C" initialAmount="2" substanceUnits="substance" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
-      <species id="S3" name="S3" compartment="C" initialAmount="1" substanceUnits="substance" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
+      <species id="S1" name="S1" compartment="C" initialAmount="1" substanceUnits="substance" hasOnlySubstanceUnits="true" boundaryCondition="false" constant="false"/>
+      <species id="S2" name="S2" compartment="C" initialAmount="2" substanceUnits="substance" hasOnlySubstanceUnits="true" boundaryCondition="false" constant="false"/>
+      <species id="S3" name="S3" compartment="C" initialAmount="1" substanceUnits="substance" hasOnlySubstanceUnits="true" boundaryCondition="false" constant="false"/>
     </listOfSpecies>
     <listOfParameters>
       <parameter id="k1" name="k1" value="0.8" constant="true"/>

--- a/cases/semantic/00365/00365-sbml-l3v1.xml
+++ b/cases/semantic/00365/00365-sbml-l3v1.xml
@@ -17,9 +17,9 @@
       <compartment id="C" name="C" spatialDimensions="0" constant="true"/>
     </listOfCompartments>
     <listOfSpecies>
-      <species id="S1" name="S1" compartment="C" initialAmount="1" substanceUnits="substance" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
-      <species id="S2" name="S2" compartment="C" initialAmount="2" substanceUnits="substance" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
-      <species id="S3" name="S3" compartment="C" initialAmount="1" substanceUnits="substance" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
+      <species id="S1" name="S1" compartment="C" initialAmount="1" substanceUnits="substance" hasOnlySubstanceUnits="true" boundaryCondition="false" constant="false"/>
+      <species id="S2" name="S2" compartment="C" initialAmount="2" substanceUnits="substance" hasOnlySubstanceUnits="true" boundaryCondition="false" constant="false"/>
+      <species id="S3" name="S3" compartment="C" initialAmount="1" substanceUnits="substance" hasOnlySubstanceUnits="true" boundaryCondition="false" constant="false"/>
     </listOfSpecies>
     <listOfParameters>
       <parameter id="k1" name="k1" value="0.075" constant="true"/>

--- a/cases/semantic/00365/00365-sbml-l3v2.xml
+++ b/cases/semantic/00365/00365-sbml-l3v2.xml
@@ -17,9 +17,9 @@
       <compartment id="C" name="C" spatialDimensions="0" constant="true"/>
     </listOfCompartments>
     <listOfSpecies>
-      <species id="S1" name="S1" compartment="C" initialAmount="1" substanceUnits="substance" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
-      <species id="S2" name="S2" compartment="C" initialAmount="2" substanceUnits="substance" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
-      <species id="S3" name="S3" compartment="C" initialAmount="1" substanceUnits="substance" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
+      <species id="S1" name="S1" compartment="C" initialAmount="1" substanceUnits="substance" hasOnlySubstanceUnits="true" boundaryCondition="false" constant="false"/>
+      <species id="S2" name="S2" compartment="C" initialAmount="2" substanceUnits="substance" hasOnlySubstanceUnits="true" boundaryCondition="false" constant="false"/>
+      <species id="S3" name="S3" compartment="C" initialAmount="1" substanceUnits="substance" hasOnlySubstanceUnits="true" boundaryCondition="false" constant="false"/>
     </listOfSpecies>
     <listOfParameters>
       <parameter id="k1" name="k1" value="0.075" constant="true"/>

--- a/cases/semantic/00368/00368-sbml-l3v1.xml
+++ b/cases/semantic/00368/00368-sbml-l3v1.xml
@@ -17,9 +17,9 @@
       <compartment id="C" name="C" spatialDimensions="0" constant="true"/>
     </listOfCompartments>
     <listOfSpecies>
-      <species id="S1" name="S1" compartment="C" initialAmount="1" substanceUnits="substance" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
-      <species id="S2" name="S2" compartment="C" initialAmount="2" substanceUnits="substance" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
-      <species id="S3" name="S3" compartment="C" initialAmount="1" substanceUnits="substance" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
+      <species id="S1" name="S1" compartment="C" initialAmount="1" substanceUnits="substance" hasOnlySubstanceUnits="true" boundaryCondition="false" constant="false"/>
+      <species id="S2" name="S2" compartment="C" initialAmount="2" substanceUnits="substance" hasOnlySubstanceUnits="true" boundaryCondition="false" constant="false"/>
+      <species id="S3" name="S3" compartment="C" initialAmount="1" substanceUnits="substance" hasOnlySubstanceUnits="true" boundaryCondition="false" constant="false"/>
     </listOfSpecies>
     <listOfParameters>
       <parameter id="k1" name="k1" value="0.75" constant="true"/>

--- a/cases/semantic/00368/00368-sbml-l3v2.xml
+++ b/cases/semantic/00368/00368-sbml-l3v2.xml
@@ -17,9 +17,9 @@
       <compartment id="C" name="C" spatialDimensions="0" constant="true"/>
     </listOfCompartments>
     <listOfSpecies>
-      <species id="S1" name="S1" compartment="C" initialAmount="1" substanceUnits="substance" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
-      <species id="S2" name="S2" compartment="C" initialAmount="2" substanceUnits="substance" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
-      <species id="S3" name="S3" compartment="C" initialAmount="1" substanceUnits="substance" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
+      <species id="S1" name="S1" compartment="C" initialAmount="1" substanceUnits="substance" hasOnlySubstanceUnits="true" boundaryCondition="false" constant="false"/>
+      <species id="S2" name="S2" compartment="C" initialAmount="2" substanceUnits="substance" hasOnlySubstanceUnits="true" boundaryCondition="false" constant="false"/>
+      <species id="S3" name="S3" compartment="C" initialAmount="1" substanceUnits="substance" hasOnlySubstanceUnits="true" boundaryCondition="false" constant="false"/>
     </listOfSpecies>
     <listOfParameters>
       <parameter id="k1" name="k1" value="0.75" constant="true"/>

--- a/cases/semantic/00419/00419-sbml-l3v1.xml
+++ b/cases/semantic/00419/00419-sbml-l3v1.xml
@@ -17,9 +17,9 @@
       <compartment id="C" name="C" spatialDimensions="0" constant="true"/>
     </listOfCompartments>
     <listOfSpecies>
-      <species id="S1" name="S1" compartment="C" initialAmount="1" substanceUnits="substance" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
-      <species id="S2" name="S2" compartment="C" initialAmount="2" substanceUnits="substance" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
-      <species id="S3" name="S3" compartment="C" initialAmount="1" substanceUnits="substance" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
+      <species id="S1" name="S1" compartment="C" initialAmount="1" substanceUnits="substance" hasOnlySubstanceUnits="true" boundaryCondition="false" constant="false"/>
+      <species id="S2" name="S2" compartment="C" initialAmount="2" substanceUnits="substance" hasOnlySubstanceUnits="true" boundaryCondition="false" constant="false"/>
+      <species id="S3" name="S3" compartment="C" initialAmount="1" substanceUnits="substance" hasOnlySubstanceUnits="true" boundaryCondition="false" constant="false"/>
     </listOfSpecies>
     <listOfParameters>
       <parameter id="k1" name="k1" value="0.8" constant="true"/>

--- a/cases/semantic/00419/00419-sbml-l3v2.xml
+++ b/cases/semantic/00419/00419-sbml-l3v2.xml
@@ -17,9 +17,9 @@
       <compartment id="C" name="C" spatialDimensions="0" constant="true"/>
     </listOfCompartments>
     <listOfSpecies>
-      <species id="S1" name="S1" compartment="C" initialAmount="1" substanceUnits="substance" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
-      <species id="S2" name="S2" compartment="C" initialAmount="2" substanceUnits="substance" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
-      <species id="S3" name="S3" compartment="C" initialAmount="1" substanceUnits="substance" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
+      <species id="S1" name="S1" compartment="C" initialAmount="1" substanceUnits="substance" hasOnlySubstanceUnits="true" boundaryCondition="false" constant="false"/>
+      <species id="S2" name="S2" compartment="C" initialAmount="2" substanceUnits="substance" hasOnlySubstanceUnits="true" boundaryCondition="false" constant="false"/>
+      <species id="S3" name="S3" compartment="C" initialAmount="1" substanceUnits="substance" hasOnlySubstanceUnits="true" boundaryCondition="false" constant="false"/>
     </listOfSpecies>
     <listOfParameters>
       <parameter id="k1" name="k1" value="0.8" constant="true"/>

--- a/cases/semantic/00422/00422-sbml-l3v1.xml
+++ b/cases/semantic/00422/00422-sbml-l3v1.xml
@@ -17,9 +17,9 @@
       <compartment id="C" name="C" spatialDimensions="0" constant="true"/>
     </listOfCompartments>
     <listOfSpecies>
-      <species id="S1" name="S1" compartment="C" initialAmount="1" substanceUnits="substance" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
-      <species id="S2" name="S2" compartment="C" initialAmount="2" substanceUnits="substance" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
-      <species id="S3" name="S3" compartment="C" initialAmount="1" substanceUnits="substance" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
+      <species id="S1" name="S1" compartment="C" initialAmount="1" substanceUnits="substance" hasOnlySubstanceUnits="true" boundaryCondition="false" constant="false"/>
+      <species id="S2" name="S2" compartment="C" initialAmount="2" substanceUnits="substance" hasOnlySubstanceUnits="true" boundaryCondition="false" constant="false"/>
+      <species id="S3" name="S3" compartment="C" initialAmount="1" substanceUnits="substance" hasOnlySubstanceUnits="true" boundaryCondition="false" constant="false"/>
     </listOfSpecies>
     <listOfParameters>
       <parameter id="k1" name="k1" value="0.075" constant="true"/>

--- a/cases/semantic/00422/00422-sbml-l3v2.xml
+++ b/cases/semantic/00422/00422-sbml-l3v2.xml
@@ -17,9 +17,9 @@
       <compartment id="C" name="C" spatialDimensions="0" constant="true"/>
     </listOfCompartments>
     <listOfSpecies>
-      <species id="S1" name="S1" compartment="C" initialAmount="1" substanceUnits="substance" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
-      <species id="S2" name="S2" compartment="C" initialAmount="2" substanceUnits="substance" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
-      <species id="S3" name="S3" compartment="C" initialAmount="1" substanceUnits="substance" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
+      <species id="S1" name="S1" compartment="C" initialAmount="1" substanceUnits="substance" hasOnlySubstanceUnits="true" boundaryCondition="false" constant="false"/>
+      <species id="S2" name="S2" compartment="C" initialAmount="2" substanceUnits="substance" hasOnlySubstanceUnits="true" boundaryCondition="false" constant="false"/>
+      <species id="S3" name="S3" compartment="C" initialAmount="1" substanceUnits="substance" hasOnlySubstanceUnits="true" boundaryCondition="false" constant="false"/>
     </listOfSpecies>
     <listOfParameters>
       <parameter id="k1" name="k1" value="0.075" constant="true"/>

--- a/cases/semantic/00425/00425-sbml-l3v1.xml
+++ b/cases/semantic/00425/00425-sbml-l3v1.xml
@@ -17,9 +17,9 @@
       <compartment id="C" name="C" spatialDimensions="0" constant="true"/>
     </listOfCompartments>
     <listOfSpecies>
-      <species id="S1" name="S1" compartment="C" initialAmount="1" substanceUnits="substance" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
-      <species id="S2" name="S2" compartment="C" initialAmount="2" substanceUnits="substance" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
-      <species id="S3" name="S3" compartment="C" initialAmount="1" substanceUnits="substance" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
+      <species id="S1" name="S1" compartment="C" initialAmount="1" substanceUnits="substance" hasOnlySubstanceUnits="true" boundaryCondition="false" constant="false"/>
+      <species id="S2" name="S2" compartment="C" initialAmount="2" substanceUnits="substance" hasOnlySubstanceUnits="true" boundaryCondition="false" constant="false"/>
+      <species id="S3" name="S3" compartment="C" initialAmount="1" substanceUnits="substance" hasOnlySubstanceUnits="true" boundaryCondition="false" constant="false"/>
     </listOfSpecies>
     <listOfParameters>
       <parameter id="k1" name="k1" value="0.75" constant="true"/>

--- a/cases/semantic/00425/00425-sbml-l3v2.xml
+++ b/cases/semantic/00425/00425-sbml-l3v2.xml
@@ -17,9 +17,9 @@
       <compartment id="C" name="C" spatialDimensions="0" constant="true"/>
     </listOfCompartments>
     <listOfSpecies>
-      <species id="S1" name="S1" compartment="C" initialAmount="1" substanceUnits="substance" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
-      <species id="S2" name="S2" compartment="C" initialAmount="2" substanceUnits="substance" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
-      <species id="S3" name="S3" compartment="C" initialAmount="1" substanceUnits="substance" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
+      <species id="S1" name="S1" compartment="C" initialAmount="1" substanceUnits="substance" hasOnlySubstanceUnits="true" boundaryCondition="false" constant="false"/>
+      <species id="S2" name="S2" compartment="C" initialAmount="2" substanceUnits="substance" hasOnlySubstanceUnits="true" boundaryCondition="false" constant="false"/>
+      <species id="S3" name="S3" compartment="C" initialAmount="1" substanceUnits="substance" hasOnlySubstanceUnits="true" boundaryCondition="false" constant="false"/>
     </listOfSpecies>
     <listOfParameters>
       <parameter id="k1" name="k1" value="0.75" constant="true"/>

--- a/cases/semantic/00489/00489-sbml-l3v1.xml
+++ b/cases/semantic/00489/00489-sbml-l3v1.xml
@@ -17,9 +17,9 @@
       <compartment id="C" name="C" spatialDimensions="0" constant="true"/>
     </listOfCompartments>
     <listOfSpecies>
-      <species id="S1" name="S1" compartment="C" initialAmount="0.01" substanceUnits="substance" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
-      <species id="S2" name="S2" compartment="C" initialAmount="0.02" substanceUnits="substance" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
-      <species id="S3" name="S3" compartment="C" initialAmount="0.01" substanceUnits="substance" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
+      <species id="S1" name="S1" compartment="C" initialAmount="0.01" substanceUnits="substance" hasOnlySubstanceUnits="true" boundaryCondition="false" constant="false"/>
+      <species id="S2" name="S2" compartment="C" initialAmount="0.02" substanceUnits="substance" hasOnlySubstanceUnits="true" boundaryCondition="false" constant="false"/>
+      <species id="S3" name="S3" compartment="C" initialAmount="0.01" substanceUnits="substance" hasOnlySubstanceUnits="true" boundaryCondition="false" constant="false"/>
     </listOfSpecies>
     <listOfParameters>
       <parameter id="k1" name="k1" value="0.75" constant="true"/>

--- a/cases/semantic/00489/00489-sbml-l3v2.xml
+++ b/cases/semantic/00489/00489-sbml-l3v2.xml
@@ -17,9 +17,9 @@
       <compartment id="C" name="C" spatialDimensions="0" constant="true"/>
     </listOfCompartments>
     <listOfSpecies>
-      <species id="S1" name="S1" compartment="C" initialAmount="0.01" substanceUnits="substance" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
-      <species id="S2" name="S2" compartment="C" initialAmount="0.02" substanceUnits="substance" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
-      <species id="S3" name="S3" compartment="C" initialAmount="0.01" substanceUnits="substance" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
+      <species id="S1" name="S1" compartment="C" initialAmount="0.01" substanceUnits="substance" hasOnlySubstanceUnits="true" boundaryCondition="false" constant="false"/>
+      <species id="S2" name="S2" compartment="C" initialAmount="0.02" substanceUnits="substance" hasOnlySubstanceUnits="true" boundaryCondition="false" constant="false"/>
+      <species id="S3" name="S3" compartment="C" initialAmount="0.01" substanceUnits="substance" hasOnlySubstanceUnits="true" boundaryCondition="false" constant="false"/>
     </listOfSpecies>
     <listOfParameters>
       <parameter id="k1" name="k1" value="0.75" constant="true"/>

--- a/cases/semantic/00490/00490-sbml-l3v1.xml
+++ b/cases/semantic/00490/00490-sbml-l3v1.xml
@@ -17,9 +17,9 @@
       <compartment id="C" name="C" spatialDimensions="0" constant="true"/>
     </listOfCompartments>
     <listOfSpecies>
-      <species id="S1" name="S1" compartment="C" initialAmount="2.5e-005" substanceUnits="substance" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
-      <species id="S2" name="S2" compartment="C" initialAmount="0.0002" substanceUnits="substance" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
-      <species id="S3" name="S3" compartment="C" initialAmount="0.0001" substanceUnits="substance" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
+      <species id="S1" name="S1" compartment="C" initialAmount="2.5e-005" substanceUnits="substance" hasOnlySubstanceUnits="true" boundaryCondition="false" constant="false"/>
+      <species id="S2" name="S2" compartment="C" initialAmount="0.0002" substanceUnits="substance" hasOnlySubstanceUnits="true" boundaryCondition="false" constant="false"/>
+      <species id="S3" name="S3" compartment="C" initialAmount="0.0001" substanceUnits="substance" hasOnlySubstanceUnits="true" boundaryCondition="false" constant="false"/>
     </listOfSpecies>
     <listOfParameters>
       <parameter id="k1" name="k1" value="0.75" constant="true"/>

--- a/cases/semantic/00490/00490-sbml-l3v2.xml
+++ b/cases/semantic/00490/00490-sbml-l3v2.xml
@@ -17,9 +17,9 @@
       <compartment id="C" name="C" spatialDimensions="0" constant="true"/>
     </listOfCompartments>
     <listOfSpecies>
-      <species id="S1" name="S1" compartment="C" initialAmount="2.5e-05" substanceUnits="substance" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
-      <species id="S2" name="S2" compartment="C" initialAmount="0.0002" substanceUnits="substance" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
-      <species id="S3" name="S3" compartment="C" initialAmount="0.0001" substanceUnits="substance" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
+      <species id="S1" name="S1" compartment="C" initialAmount="2.5e-05" substanceUnits="substance" hasOnlySubstanceUnits="true" boundaryCondition="false" constant="false"/>
+      <species id="S2" name="S2" compartment="C" initialAmount="0.0002" substanceUnits="substance" hasOnlySubstanceUnits="true" boundaryCondition="false" constant="false"/>
+      <species id="S3" name="S3" compartment="C" initialAmount="0.0001" substanceUnits="substance" hasOnlySubstanceUnits="true" boundaryCondition="false" constant="false"/>
     </listOfSpecies>
     <listOfParameters>
       <parameter id="k1" name="k1" value="0.75" constant="true"/>

--- a/cases/semantic/00491/00491-sbml-l3v1.xml
+++ b/cases/semantic/00491/00491-sbml-l3v1.xml
@@ -17,9 +17,9 @@
       <compartment id="C" name="C" spatialDimensions="0" constant="true"/>
     </listOfCompartments>
     <listOfSpecies>
-      <species id="S1" name="S1" compartment="C" substanceUnits="substance" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
-      <species id="S2" name="S2" compartment="C" initialAmount="0.2" substanceUnits="substance" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
-      <species id="S3" name="S3" compartment="C" initialAmount="0.1" substanceUnits="substance" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
+      <species id="S1" name="S1" compartment="C" substanceUnits="substance" hasOnlySubstanceUnits="true" boundaryCondition="false" constant="false"/>
+      <species id="S2" name="S2" compartment="C" initialAmount="0.2" substanceUnits="substance" hasOnlySubstanceUnits="true" boundaryCondition="false" constant="false"/>
+      <species id="S3" name="S3" compartment="C" initialAmount="0.1" substanceUnits="substance" hasOnlySubstanceUnits="true" boundaryCondition="false" constant="false"/>
     </listOfSpecies>
     <listOfParameters>
       <parameter id="k1" name="k1" value="0.75" constant="true"/>

--- a/cases/semantic/00491/00491-sbml-l3v2.xml
+++ b/cases/semantic/00491/00491-sbml-l3v2.xml
@@ -17,9 +17,9 @@
       <compartment id="C" name="C" spatialDimensions="0" constant="true"/>
     </listOfCompartments>
     <listOfSpecies>
-      <species id="S1" name="S1" compartment="C" substanceUnits="substance" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
-      <species id="S2" name="S2" compartment="C" initialAmount="0.2" substanceUnits="substance" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
-      <species id="S3" name="S3" compartment="C" initialAmount="0.1" substanceUnits="substance" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
+      <species id="S1" name="S1" compartment="C" substanceUnits="substance" hasOnlySubstanceUnits="true" boundaryCondition="false" constant="false"/>
+      <species id="S2" name="S2" compartment="C" initialAmount="0.2" substanceUnits="substance" hasOnlySubstanceUnits="true" boundaryCondition="false" constant="false"/>
+      <species id="S3" name="S3" compartment="C" initialAmount="0.1" substanceUnits="substance" hasOnlySubstanceUnits="true" boundaryCondition="false" constant="false"/>
     </listOfSpecies>
     <listOfParameters>
       <parameter id="k1" name="k1" value="0.75" constant="true"/>

--- a/cases/semantic/00543/00543-sbml-l3v1.xml
+++ b/cases/semantic/00543/00543-sbml-l3v1.xml
@@ -17,10 +17,10 @@
       <compartment id="C" name="C" spatialDimensions="0" constant="true"/>
     </listOfCompartments>
     <listOfSpecies>
-      <species id="X0" name="X0" compartment="C" initialAmount="1" substanceUnits="substance" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
-      <species id="X1" name="X1" compartment="C" initialAmount="0" substanceUnits="substance" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
-      <species id="T" name="T" compartment="C" initialAmount="0" substanceUnits="substance" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
-      <species id="S1" name="S1" compartment="C" initialAmount="0" substanceUnits="substance" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
+      <species id="X0" name="X0" compartment="C" initialAmount="1" substanceUnits="substance" hasOnlySubstanceUnits="true" boundaryCondition="false" constant="false"/>
+      <species id="X1" name="X1" compartment="C" initialAmount="0" substanceUnits="substance" hasOnlySubstanceUnits="true" boundaryCondition="false" constant="false"/>
+      <species id="T" name="T" compartment="C" initialAmount="0" substanceUnits="substance" hasOnlySubstanceUnits="true" boundaryCondition="false" constant="false"/>
+      <species id="S1" name="S1" compartment="C" initialAmount="0" substanceUnits="substance" hasOnlySubstanceUnits="true" boundaryCondition="false" constant="false"/>
     </listOfSpecies>
     <listOfParameters>
       <parameter id="k1" name="k1" value="0.1" constant="true"/>

--- a/cases/semantic/00543/00543-sbml-l3v2.xml
+++ b/cases/semantic/00543/00543-sbml-l3v2.xml
@@ -17,10 +17,10 @@
       <compartment id="C" name="C" spatialDimensions="0" constant="true"/>
     </listOfCompartments>
     <listOfSpecies>
-      <species id="X0" name="X0" compartment="C" initialAmount="1" substanceUnits="substance" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
-      <species id="X1" name="X1" compartment="C" initialAmount="0" substanceUnits="substance" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
-      <species id="T" name="T" compartment="C" initialAmount="0" substanceUnits="substance" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
-      <species id="S1" name="S1" compartment="C" initialAmount="0" substanceUnits="substance" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
+      <species id="X0" name="X0" compartment="C" initialAmount="1" substanceUnits="substance" hasOnlySubstanceUnits="true" boundaryCondition="false" constant="false"/>
+      <species id="X1" name="X1" compartment="C" initialAmount="0" substanceUnits="substance" hasOnlySubstanceUnits="true" boundaryCondition="false" constant="false"/>
+      <species id="T" name="T" compartment="C" initialAmount="0" substanceUnits="substance" hasOnlySubstanceUnits="true" boundaryCondition="false" constant="false"/>
+      <species id="S1" name="S1" compartment="C" initialAmount="0" substanceUnits="substance" hasOnlySubstanceUnits="true" boundaryCondition="false" constant="false"/>
     </listOfSpecies>
     <listOfParameters>
       <parameter id="k1" name="k1" value="0.1" constant="true"/>

--- a/cases/semantic/00546/00546-sbml-l3v1.xml
+++ b/cases/semantic/00546/00546-sbml-l3v1.xml
@@ -17,10 +17,10 @@
       <compartment id="C" name="C" spatialDimensions="0" constant="true"/>
     </listOfCompartments>
     <listOfSpecies>
-      <species id="S1" name="S1" compartment="C" initialAmount="0.0001" substanceUnits="substance" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
-      <species id="S2" name="S2" compartment="C" initialAmount="0.0002" substanceUnits="substance" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
-      <species id="S3" name="S3" compartment="C" initialAmount="0.0001" substanceUnits="substance" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
-      <species id="S4" name="S4" compartment="C" initialAmount="0.0001" substanceUnits="substance" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
+      <species id="S1" name="S1" compartment="C" initialAmount="0.0001" substanceUnits="substance" hasOnlySubstanceUnits="true" boundaryCondition="false" constant="false"/>
+      <species id="S2" name="S2" compartment="C" initialAmount="0.0002" substanceUnits="substance" hasOnlySubstanceUnits="true" boundaryCondition="false" constant="false"/>
+      <species id="S3" name="S3" compartment="C" initialAmount="0.0001" substanceUnits="substance" hasOnlySubstanceUnits="true" boundaryCondition="false" constant="false"/>
+      <species id="S4" name="S4" compartment="C" initialAmount="0.0001" substanceUnits="substance" hasOnlySubstanceUnits="true" boundaryCondition="false" constant="false"/>
     </listOfSpecies>
     <listOfParameters>
       <parameter id="k1" name="k1" value="0.75" constant="true"/>

--- a/cases/semantic/00546/00546-sbml-l3v2.xml
+++ b/cases/semantic/00546/00546-sbml-l3v2.xml
@@ -17,10 +17,10 @@
       <compartment id="C" name="C" spatialDimensions="0" constant="true"/>
     </listOfCompartments>
     <listOfSpecies>
-      <species id="S1" name="S1" compartment="C" initialAmount="0.0001" substanceUnits="substance" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
-      <species id="S2" name="S2" compartment="C" initialAmount="0.0002" substanceUnits="substance" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
-      <species id="S3" name="S3" compartment="C" initialAmount="0.0001" substanceUnits="substance" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
-      <species id="S4" name="S4" compartment="C" initialAmount="0.0001" substanceUnits="substance" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
+      <species id="S1" name="S1" compartment="C" initialAmount="0.0001" substanceUnits="substance" hasOnlySubstanceUnits="true" boundaryCondition="false" constant="false"/>
+      <species id="S2" name="S2" compartment="C" initialAmount="0.0002" substanceUnits="substance" hasOnlySubstanceUnits="true" boundaryCondition="false" constant="false"/>
+      <species id="S3" name="S3" compartment="C" initialAmount="0.0001" substanceUnits="substance" hasOnlySubstanceUnits="true" boundaryCondition="false" constant="false"/>
+      <species id="S4" name="S4" compartment="C" initialAmount="0.0001" substanceUnits="substance" hasOnlySubstanceUnits="true" boundaryCondition="false" constant="false"/>
     </listOfSpecies>
     <listOfParameters>
       <parameter id="k1" name="k1" value="0.75" constant="true"/>


### PR DESCRIPTION
Change all L3 species in 0D compartments without sizes to be set hasOnlySubstanceUnits=true.

The other option is to remove the L3 versions of these tests, but I think the semantics are similar enough to keep them.